### PR TITLE
ZON-2898: Add colorpicker for article teaser images

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.content.image changes
 ==========================
 
-2.12.1 (unreleased)
+2.13.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add ``IImages.fill_color`` (ZON-2898).
 
 
 2.12.0 (2016-02-29)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.content.image',
-    version='2.12.1.dev0',
+    version='2.13.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/content/image/imagereference.py
+++ b/src/zeit/content/image/imagereference.py
@@ -19,6 +19,10 @@ class ImagesAdapter(zeit.cms.related.related.RelatedBase):
     image = zeit.cms.content.reference.SingleResource(
         '.head.image', 'image')
 
+    fill_color = zeit.cms.content.property.ObjectPathAttributeProperty(
+        '.head.image', 'fill_color',
+        zeit.content.image.interfaces.IImages['fill_color'])
+
 
 class LocalOverride(object):
 

--- a/src/zeit/content/image/interfaces.py
+++ b/src/zeit/content/image/interfaces.py
@@ -137,7 +137,7 @@ class IThumbnailFolder(zope.interface.Interface):
 
 
 class MasterImageSource(
-    zc.sourcefactory.contextual.BasicContextualSourceFactory):
+        zc.sourcefactory.contextual.BasicContextualSourceFactory):
 
     def getValues(self, context):
         repository = zope.component.getUtility(
@@ -301,6 +301,11 @@ class IImages(zope.interface.Interface):
         description=_("Drag an image group here"),
         required=False,
         source=imageGroupSource)
+
+    fill_color = zope.schema.TextLine(
+        title=_("Alpha channel fill color"),
+        required=False,
+        max_length=6, constraint=zeit.cms.content.interfaces.hex_literal)
 
 
 class IReferences(zope.interface.Interface):

--- a/src/zeit/content/image/testing.py
+++ b/src/zeit/content/image/testing.py
@@ -64,7 +64,10 @@ def create_image_group_with_master_image(file_name=None):
         file_name = 'DSC00109_2.JPG'
         fh = repository['2006'][file_name].open()
     else:
-        fh = open(file_name)
+        try:
+            fh = zeit.cms.interfaces.ICMSContent(file_name).open()
+        except TypeError:
+            fh = open(file_name)
     extension = os.path.splitext(file_name)[-1].lower()
 
     group = zeit.content.image.imagegroup.ImageGroup()

--- a/src/zeit/content/image/tests/test_imagereference.py
+++ b/src/zeit/content/image/tests/test_imagereference.py
@@ -97,6 +97,12 @@ class ImageReferenceTest(zeit.cms.testing.FunctionalTestCase):
                     content)
                 updater.update(content.xml, suppress_errors=True)
 
+    def test_colorpicker_should_generate_proper_xml(self):
+        content = self.repository['testcontent']
+        zeit.content.image.interfaces.IImages(content).fill_color = u'F00F00'
+        assert len(content.xml.xpath(
+            '//head/image[@fill_color="F00F00"]')) == 1
+
 
 class MoveReferencesTest(zeit.cms.testing.FunctionalTestCase):
 


### PR DESCRIPTION
https://github.com/ZeitOnline/zeit.content.image/pull/4
https://github.com/ZeitOnline/zeit.content.cp/pull/9
https://github.com/ZeitOnline/zeit.cms/pull/10
https://github.com/ZeitOnline/zeit.content.article/pull/2
