### PR TITLE
ZON-2029: Allow materialized images to serve as transformation source

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ zeit.content.image changes
 2.13.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Allow materialized images with legacy names to serve as source for
+  size and fill color transformation (ZON-2029)
 
 
 2.13.2 (2016-04-18)

--- a/src/zeit/content/image/tests/test_imagegroup.py
+++ b/src/zeit/content/image/tests/test_imagegroup.py
@@ -1,6 +1,7 @@
 from zeit.content.image.testing import create_image_group_with_master_image
 from zeit.content.image.testing import create_local_image
 import mock
+import PIL
 import zeit.cms.testing
 import zeit.content.image.testing
 
@@ -43,6 +44,27 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
         image = self.group['540x304']
         self.assertTrue(zeit.content.image.interfaces.IImage.providedBy(image))
         self.assertEqual((120, 120), image.getImageSize())
+
+    def test_getitem_can_scale_materialized_files_for_new_syntax(self):
+        master = PIL.Image.open(self.group['540x304__80x80'].open())
+        master_sample = master.getpixel((40, 20))
+        self.group['master-image-540x304.jpg'] = create_local_image(
+            'obama-clinton-120x120.jpg')
+        materialized = PIL.Image.open(self.group['540x304__80x80'].open())
+        materialized_sample = materialized.getpixel((40, 20))
+        self.assertNotEqual(master_sample, materialized_sample)
+        self.assertEqual((80, 80), materialized.size)
+
+    def test_getitem_can_scale_materialized_files_with_legacy_name(self):
+        master = PIL.Image.open(self.group['540x304__80x80'].open())
+        master_sample = master.getpixel((40, 20))
+        self.group['master-image-540x304.jpg'] = create_local_image(
+            'obama-clinton-120x120.jpg')
+        materialized = PIL.Image.open(
+            self.group['master-image-540x304__80x80'].open())
+        materialized_sample = materialized.getpixel((40, 20))
+        self.assertNotEqual(master_sample, materialized_sample)
+        self.assertEqual((80, 80), materialized.size)
 
     def test_getitem_raises_keyerror_if_variant_does_not_exist(self):
         with self.assertRaises(KeyError):


### PR DESCRIPTION
We need this to get rid of bitblt rendering direct image includes in older article headers. This allows on-disk variants to serve as a source for transformation, while preserving any manual adjustments, that would have been lost if we would have just used the master image and a default focus point to regenerate the image.
