### PR TITLE
ZON-3171: Enable display of a different motif depending on additional URL modifier

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,8 @@ zeit.content.image changes
 
 - Render variants using the master image for given viewport. (ZON-3171)
 
+- Remove dependency to `zeit.imp`. (ZON-3171)
+
 
 2.13.5 (2016-06-27)
 -------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.image changes
 2.13.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Allow breakpoint modifier inside URL of image variants. (ZON-3171)
 
 
 2.13.5 (2016-06-27)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.image changes
 2.13.6 (unreleased)
 -------------------
 
-- Allow breakpoint modifier inside URL of image variants. (ZON-3171)
+- Allow viewport modifier inside URL of image variants. (ZON-3171)
 
 
 2.13.5 (2016-06-27)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ zeit.content.image changes
 - Store multiple master images and which viewport they should be used for,
   rather allowing a single master image for everything. (ZON-3171)
 
+- Render variants using the master image for given viewport. (ZON-3171)
+
 
 2.13.5 (2016-06-27)
 -------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ zeit.content.image changes
 
 - Allow viewport modifier inside URL of image variants. (ZON-3171)
 
+- Store multiple master images and which viewport they should be used for,
+  rather allowing a single master image for everything. (ZON-3171)
+
 
 2.13.5 (2016-06-27)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         'zeit.cms>=2.46.0.dev0',
         'zeit.connector>=2.4.0.dev0',
         'zeit.edit>=2.11.3.dev0',
-        'zeit.imp>=0.15.0.dev0',
         'zeit.wysiwyg',
         'zope.app.appsetup',
         'zope.app.container',

--- a/src/zeit/content/image/browser/README.txt
+++ b/src/zeit/content/image/browser/README.txt
@@ -346,7 +346,7 @@ Lets create an image group:
 ...     'ZEIT ONLINE')
 >>> browser.getControl(name='form.copyrights.0..combination_01').value = (
 ...     'http://www.zeit.de/')
->>> set_file_data('opernball.jpg', 'primary_master_image_blob')
+>>> set_file_data('opernball.jpg', 'master_image_blobs.0.')
 >>> browser.getControl(name='form.actions.add').click()
 
 Image groups are not checked out by default, because adding new images will be

--- a/src/zeit/content/image/browser/README.txt
+++ b/src/zeit/content/image/browser/README.txt
@@ -196,7 +196,7 @@ Make sure the image is not changed by looking at the image view:
         <a href="http://www.zeit.de">http://www.zeit.de</a>
       </div>
       ...
-  
+
 
 
 Dragging
@@ -333,11 +333,11 @@ Lets create an image group:
 
 [#no-references]_
 
->>> def set_file_data(name):
+>>> def set_file_data(name, field):
 ...     test_file = os.path.join(
 ...         os.path.dirname(__file__), 'testdata', name)
 ...     test_data = file(test_file, 'rb')
-...     file_control = browser.getControl(name='form.blob')
+...     file_control = browser.getControl(name='form.' + field)
 ...     file_control.add_file(test_data, 'image/jpeg', name)
 
 >>> browser.getControl("File name").value = 'new-hampshire'
@@ -346,7 +346,7 @@ Lets create an image group:
 ...     'ZEIT ONLINE')
 >>> browser.getControl(name='form.copyrights.0..combination_01').value = (
 ...     'http://www.zeit.de/')
->>> set_file_data('opernball.jpg')
+>>> set_file_data('opernball.jpg', 'primary_master_image_blob')
 >>> browser.getControl(name='form.actions.add').click()
 
 Image groups are not checked out by default, because adding new images will be
@@ -379,7 +379,7 @@ LookupError: label 'Volume'...
 
 Set the file data:
 
->>> set_file_data('new-hampshire-artikel.jpg')
+>>> set_file_data('new-hampshire-artikel.jpg', 'blob')
 >>> browser.getControl('Add').click()
 
 After adding the image we're back at the image group:
@@ -393,7 +393,7 @@ So we can directly add the next image:
 >>> menu = browser.getControl(name='add_menu')
 >>> menu.displayValue = ['Image']
 >>> browser.open(menu.value[0])
->>> set_file_data('new-hampshire-450x200.jpg')
+>>> set_file_data('new-hampshire-450x200.jpg', 'blob')
 >>> browser.getControl('Add').click()
 
 And another one:
@@ -402,7 +402,7 @@ And another one:
 >>> menu = browser.getControl(name='add_menu')
 >>> menu.displayValue = ['Image']
 >>> browser.open(menu.value[0])
->>> set_file_data('obama-clinton-120x120.jpg')
+>>> set_file_data('obama-clinton-120x120.jpg', 'blob')
 >>> browser.getControl('Add').click()
 
 Let's have a look at the file list:

--- a/src/zeit/content/image/browser/configure.zcml
+++ b/src/zeit/content/image/browser/configure.zcml
@@ -314,7 +314,7 @@
     name="variant.html"
     class=".variant.Editor"
     template="image-variants.pt"
-    menu="zeit-context-views" title="Variants"
+    menu="zeit-context-views" title="Edit"
     permission="zope.View"
     />
 

--- a/src/zeit/content/image/browser/copyright.txt
+++ b/src/zeit/content/image/browser/copyright.txt
@@ -18,7 +18,7 @@ Add an image group because one object is boring:
 ...     test_file = os.path.join(
 ...         os.path.dirname(__file__), 'testdata', name)
 ...     test_data = file(test_file, 'rb')
-...     file_control = browser.getControl(name='form.blob')
+...     file_control = browser.getControl(name='form.primary_master_image_blob')
 ...     file_control.add_file(test_data, 'image/jpeg', name)
 >>> set_file_data('new-hampshire-artikel.jpg')
 

--- a/src/zeit/content/image/browser/copyright.txt
+++ b/src/zeit/content/image/browser/copyright.txt
@@ -18,7 +18,7 @@ Add an image group because one object is boring:
 ...     test_file = os.path.join(
 ...         os.path.dirname(__file__), 'testdata', name)
 ...     test_data = file(test_file, 'rb')
-...     file_control = browser.getControl(name='form.primary_master_image_blob')
+...     file_control = browser.getControl(name='form.master_image_blobs.0.')
 ...     file_control.add_file(test_data, 'image/jpeg', name)
 >>> set_file_data('new-hampshire-artikel.jpg')
 

--- a/src/zeit/content/image/browser/form.py
+++ b/src/zeit/content/image/browser/form.py
@@ -14,8 +14,9 @@ class ImageFormBase(zeit.cms.repository.browser.file.FormBase):
     field_groups = (
         gocept.form.grouped.Fields(
             _("Image data"), (
-                '__name__', 'blob', 'master_images', 'references',
-                'primary_master_image_blob', 'secondary_master_image_blob'),
+                '__name__', 'blob', 'references',
+                'primary_master_image_blob', 'secondary_master_image_blob',
+                'master_images', 'infographic'),
             css_class='column-left image-form'),
         gocept.form.grouped.RemainingFields(
             _("Texts"),
@@ -24,7 +25,8 @@ class ImageFormBase(zeit.cms.repository.browser.file.FormBase):
 
     form_fields = zope.formlib.form.FormFields(
         zeit.content.image.interfaces.IImageMetadata,
-        zeit.content.image.interfaces.IReferences).omit('acquire_metadata')
+        zeit.content.image.interfaces.IReferences).omit(
+        'acquire_metadata', 'origin')
 
     def __init__(self, *args, **kw):
         self.form_fields['blob'].custom_widget = (

--- a/src/zeit/content/image/browser/form.py
+++ b/src/zeit/content/image/browser/form.py
@@ -14,7 +14,7 @@ class ImageFormBase(zeit.cms.repository.browser.file.FormBase):
     field_groups = (
         gocept.form.grouped.Fields(
             _("Image data"), (
-                '__name__', 'blob', 'master_image', 'references'),
+                '__name__', 'blob', 'master_images', 'references'),
             css_class='column-left image-form'),
         gocept.form.grouped.RemainingFields(
             _("Texts"),

--- a/src/zeit/content/image/browser/form.py
+++ b/src/zeit/content/image/browser/form.py
@@ -14,7 +14,8 @@ class ImageFormBase(zeit.cms.repository.browser.file.FormBase):
     field_groups = (
         gocept.form.grouped.Fields(
             _("Image data"), (
-                '__name__', 'blob', 'master_images', 'references'),
+                '__name__', 'blob', 'master_images', 'references',
+                'primary_master_image_blob', 'secondary_master_image_blob'),
             css_class='column-left image-form'),
         gocept.form.grouped.RemainingFields(
             _("Texts"),

--- a/src/zeit/content/image/browser/form.py
+++ b/src/zeit/content/image/browser/form.py
@@ -16,7 +16,7 @@ class ImageFormBase(zeit.cms.repository.browser.file.FormBase):
             _("Image data"), (
                 '__name__', 'blob', 'references',
                 'primary_master_image_blob', 'secondary_master_image_blob',
-                'master_images', 'infographic'),
+                'master_images', 'display_type'),
             css_class='column-left image-form'),
         gocept.form.grouped.RemainingFields(
             _("Texts"),

--- a/src/zeit/content/image/browser/form.py
+++ b/src/zeit/content/image/browser/form.py
@@ -15,7 +15,7 @@ class ImageFormBase(zeit.cms.repository.browser.file.FormBase):
         gocept.form.grouped.Fields(
             _("Image data"), (
                 '__name__', 'blob', 'references',
-                'primary_master_image_blob', 'secondary_master_image_blob',
+                'master_image_blobs',
                 'master_images', 'display_type'),
             css_class='column-left image-form'),
         gocept.form.grouped.RemainingFields(

--- a/src/zeit/content/image/browser/imagegroup.py
+++ b/src/zeit/content/image/browser/imagegroup.py
@@ -199,12 +199,12 @@ class Thumbnail(object):
         if not self.context.keys():
             raise zope.publisher.interfaces.NotFound(
                 self.context, self.__name__, self.request)
+
         for name in self.context.keys():
             if self.first_choice.match(name):
-                break
-        else:
-            name = self.context.keys()[0]
-        return self.context[name]
+                return self.context[name]
+
+        return zeit.content.image.interfaces.IMasterImage(self.context)
 
 
 class ThumbnailLarge(Thumbnail):

--- a/src/zeit/content/image/browser/imagegroup.py
+++ b/src/zeit/content/image/browser/imagegroup.py
@@ -81,7 +81,7 @@ class AddForm(FormBase,
         name = getattr(blob, 'filename', '')
         zeit.cms.browser.form.apply_changes_with_setattr(
             image,
-            self.form_fields.omit('__name__', 'infographic'), data)
+            self.form_fields.omit('__name__', 'display_type'), data)
         image.__name__ = name
         return image
 

--- a/src/zeit/content/image/browser/imagegroup.py
+++ b/src/zeit/content/image/browser/imagegroup.py
@@ -33,7 +33,7 @@ class AddForm(FormBase,
     factory = zeit.content.image.imagegroup.ImageGroup
     checkout = False
     form_fields = (
-        FormBase.form_fields.omit('references', 'master_image') +
+        FormBase.form_fields.omit('references', 'master_images') +
         zope.formlib.form.FormFields(
             zeit.content.image.browser.interfaces.IMasterImageUploadSchema))
 
@@ -43,8 +43,9 @@ class AddForm(FormBase,
     def create(self, data):
         self.image = self.create_image(data)
         group = super(AddForm, self).create(data)
+        viewports = list(zeit.content.image.interfaces.VIEWPORT_SOURCE(group))
         if self.image:
-            group.master_image = self.image.__name__
+            group.master_images = ((viewports[0], self.image.__name__),)
         return group
 
     def add(self, group):

--- a/src/zeit/content/image/browser/imagegroup.py
+++ b/src/zeit/content/image/browser/imagegroup.py
@@ -91,7 +91,7 @@ class AddForm(FormBase,
                 'zeit.content.image.variants'):
             return 'variant.html'
         else:
-            return 'imp.html'
+            return 'view.html'
 
 
 class EditForm(FormBase, zeit.cms.browser.form.EditForm):

--- a/src/zeit/content/image/browser/imagegroup.py
+++ b/src/zeit/content/image/browser/imagegroup.py
@@ -81,7 +81,7 @@ class AddForm(FormBase,
         name = getattr(blob, 'filename', '')
         zeit.cms.browser.form.apply_changes_with_setattr(
             image,
-            self.form_fields.omit('__name__'), data)
+            self.form_fields.omit('__name__', 'infographic'), data)
         image.__name__ = name
         return image
 

--- a/src/zeit/content/image/browser/imagegroup.py
+++ b/src/zeit/content/image/browser/imagegroup.py
@@ -97,11 +97,20 @@ class AddForm(FormBase,
         else:
             return 'view.html'
 
+    def setUpWidgets(self, *args, **kw):
+        super(AddForm, self).setUpWidgets(*args, **kw)
+        self.widgets['master_image_blobs'].addButtonLabel = _('Add motif')
+
 
 class EditForm(FormBase, zeit.cms.browser.form.EditForm):
 
     title = _('Edit image group')
     form_fields = FormBase.form_fields.omit('__name__')
+
+    def setUpWidgets(self, *args, **kw):
+        super(EditForm, self).setUpWidgets(*args, **kw)
+        self.widgets['master_images'].addButtonLabel = _(
+            'Add viewport to master image mapping')
 
 
 class DisplayForm(FormBase, zeit.cms.browser.form.DisplayForm):

--- a/src/zeit/content/image/browser/imagegroup.py
+++ b/src/zeit/content/image/browser/imagegroup.py
@@ -27,6 +27,8 @@ class FormBase(object):
         zeit.content.image.interfaces.IReferences).omit(
             'acquire_metadata', 'variants')
 
+    form_fields['__name__'].field.title = _('File name of image group')
+
 
 class AddForm(FormBase,
               zeit.cms.repository.browser.file.FormBase,

--- a/src/zeit/content/image/browser/interfaces.py
+++ b/src/zeit/content/image/browser/interfaces.py
@@ -45,9 +45,16 @@ class IFileEditSchema(IFileAddSchema):
 
 class IMasterImageUploadSchema(zope.interface.Interface):
 
-    blob = zope.schema.Object(
+    primary_master_image_blob = zope.schema.Object(
         zope.interface.Interface,
         title=_('Upload master image'),
         description=_('upload-master-image-description'),
         required=True,
+        constraint=is_image)
+
+    secondary_master_image_blob = zope.schema.Object(
+        zope.interface.Interface,
+        title=_('Upload secondary master image'),
+        description=_('upload-secondary-master-image-description'),
+        required=False,
         constraint=is_image)

--- a/src/zeit/content/image/browser/interfaces.py
+++ b/src/zeit/content/image/browser/interfaces.py
@@ -46,10 +46,10 @@ class IFileEditSchema(IFileAddSchema):
 class IMasterImageUploadSchema(zope.interface.Interface):
 
     master_image_blobs = zope.schema.Tuple(
-        title=_('Upload image'),
+        title=_('Upload master images'),
         unique=True,
-        min_length=1,
         required=True,
+        min_length=1,
         missing_value=(),
         value_type=zope.schema.Object(
             zope.interface.Interface,

--- a/src/zeit/content/image/browser/interfaces.py
+++ b/src/zeit/content/image/browser/interfaces.py
@@ -45,16 +45,13 @@ class IFileEditSchema(IFileAddSchema):
 
 class IMasterImageUploadSchema(zope.interface.Interface):
 
-    primary_master_image_blob = zope.schema.Object(
-        zope.interface.Interface,
-        title=_('Upload master image'),
-        description=_('upload-master-image-description'),
+    master_image_blobs = zope.schema.Tuple(
+        title=_('Upload image'),
+        unique=True,
+        min_length=1,
         required=True,
-        constraint=is_image)
-
-    secondary_master_image_blob = zope.schema.Object(
-        zope.interface.Interface,
-        title=_('Upload secondary master image'),
-        description=_('upload-secondary-master-image-description'),
-        required=False,
-        constraint=is_image)
+        missing_value=(),
+        value_type=zope.schema.Object(
+            zope.interface.Interface,
+            required=False,
+            constraint=is_image))

--- a/src/zeit/content/image/browser/master-image.txt
+++ b/src/zeit/content/image/browser/master-image.txt
@@ -78,21 +78,21 @@ It is possible to select the master image of an image group:
 
 >>> browser.open('http://localhost/++skin++cms/repository/image-group')
 >>> browser.getLink('Checkout').click()
->>> browser.getControl('Master image').displayValue
+>>> browser.getControl('Image', index=0).displayValue
 ['(nothing selected)']
->>> browser.getControl('Master image').displayOptions
+>>> browser.getControl('Image', index=0).displayOptions
 ['(nothing selected)',
  'new-hampshire-450x200.jpg',
  'new-hampshire-artikel.jpg',
  'obama-clinton-120x120.jpg']
->>> browser.getControl('Master image').displayValue = ['obama']
+>>> browser.getControl('Image', index=0).displayValue = ['obama']
 >>> browser.getControl('Viewport').displayValue = ['Desktop']
 >>> browser.getControl(name='form.copyrights.0..combination_00').value = (
 ...     'ZEIT ONLINE')
 >>> browser.getControl(name='form.copyrights.0..combination_01').value = (
 ...     'http://www.zeit.de/')
 >>> browser.getControl('Apply').click()
->>> browser.getControl('Master image').displayValue
+>>> browser.getControl('Image', index=0).displayValue
 ['obama-clinton-120x120.jpg']
 >>> print browser.contents
 <?xml ...

--- a/src/zeit/content/image/browser/master-image.txt
+++ b/src/zeit/content/image/browser/master-image.txt
@@ -86,6 +86,7 @@ It is possible to select the master image of an image group:
  'new-hampshire-artikel.jpg',
  'obama-clinton-120x120.jpg']
 >>> browser.getControl('Master image').displayValue = ['obama']
+>>> browser.getControl('Viewport').displayValue = ['Desktop']
 >>> browser.getControl(name='form.copyrights.0..combination_00').value = (
 ...     'ZEIT ONLINE')
 >>> browser.getControl(name='form.copyrights.0..combination_01').value = (

--- a/src/zeit/content/image/browser/master-image.txt
+++ b/src/zeit/content/image/browser/master-image.txt
@@ -121,7 +121,7 @@ It is possible to select the master image of an image group:
     ...     test_file = os.path.join(
     ...         os.path.dirname(__file__), 'testdata', name)
     ...     test_data = file(test_file, 'rb')
-    ...     file_control = browser.getControl(name='form.blob')
+    ...     file_control = browser.getControl(name='form.primary_master_image_blob')
     ...     file_control.filename = name
     ...     file_control.value = test_data
 

--- a/src/zeit/content/image/browser/master-image.txt
+++ b/src/zeit/content/image/browser/master-image.txt
@@ -121,7 +121,7 @@ It is possible to select the master image of an image group:
     ...     test_file = os.path.join(
     ...         os.path.dirname(__file__), 'testdata', name)
     ...     test_data = file(test_file, 'rb')
-    ...     file_control = browser.getControl(name='form.primary_master_image_blob')
+    ...     file_control = browser.getControl(name='form.master_image_blobs.0.')
     ...     file_control.filename = name
     ...     file_control.value = test_data
 

--- a/src/zeit/content/image/browser/tests/test_imagegroup.py
+++ b/src/zeit/content/image/browser/tests/test_imagegroup.py
@@ -128,3 +128,26 @@ class ImageGroupBrowserTest(
         self.assertEqual('mobile', group.master_images[1][0])
         self.assertEqual(
             'new-hampshire-artikel.jpg', group.master_images[1][1])
+
+
+class ThumbnailTest(zeit.cms.testing.FunctionalTestCase):
+
+    layer = zeit.content.image.testing.ZCML_LAYER
+
+    def setUp(self):
+        from zeit.content.image.browser.imagegroup import Thumbnail
+        super(ThumbnailTest, self).setUp()
+        self.group = create_image_group_with_master_image()
+        self.thumbnail = Thumbnail()
+        self.thumbnail.context = self.group
+
+    def test_defaults_to_master_image(self):
+        self.assertEqual(
+            self.group['master-image.jpg'], self.thumbnail._find_image())
+
+    def test_uses_materialized_image_if_present(self):
+        from zeit.content.image.testing import create_local_image
+        self.group['image-540x304.jpg'] = create_local_image(
+            'obama-clinton-120x120.jpg')
+        self.assertEqual(
+            self.group['image-540x304.jpg'], self.thumbnail._find_image())

--- a/src/zeit/content/image/browser/tests/test_imagegroup.py
+++ b/src/zeit/content/image/browser/tests/test_imagegroup.py
@@ -38,10 +38,13 @@ class ImageGroupHelperMixin(object):
             'image/jpeg', filename)
 
     def upload_primary_image(self, filename):
-        self._upload_image('primary_master_image_blob', filename)
+        self._upload_image('master_image_blobs.0.', filename)
 
     def upload_secondary_image(self, filename):
-        self._upload_image('secondary_master_image_blob', filename)
+        self._upload_image('master_image_blobs.1.', filename)
+
+    def upload_tertiary_image(self, filename):
+        self._upload_image('master_image_blobs.2.', filename)
 
     def save_imagegroup(self):
         self.browser.getControl(name='form.actions.add').click()
@@ -117,6 +120,7 @@ class ImageGroupBrowserTest(
     def test_secondary_master_image_is_marked_for_mobile_viewport(self):
         self.add_imagegroup()
         self.set_imagegroup_filename('image-group')
+        self.browser.getControl('Upload image').click()
         self.upload_primary_image('opernball.jpg')
         self.upload_secondary_image('new-hampshire-artikel.jpg')
         self.fill_copyright_information()
@@ -128,6 +132,23 @@ class ImageGroupBrowserTest(
         self.assertEqual('mobile', group.master_images[1][0])
         self.assertEqual(
             'new-hampshire-artikel.jpg', group.master_images[1][1])
+
+    def test_tertiary_master_image_has_no_viewport(self):
+        self.add_imagegroup()
+        self.set_imagegroup_filename('image-group')
+        self.browser.getControl('Upload image').click()
+        self.browser.getControl('Upload image').click()
+        self.upload_primary_image('opernball.jpg')
+        self.upload_secondary_image('new-hampshire-artikel.jpg')
+        self.upload_tertiary_image('obama-clinton-120x120.jpg')
+        self.fill_copyright_information()
+        self.save_imagegroup()
+
+        with zeit.cms.testing.site(self.getRootFolder()):
+            group = self.repository['2006']['image-group']
+        self.assertEqual(2, len(group.master_images))
+        self.assertEqual(3, len(group.keys()))
+        self.assertIn('obama-clinton-120x120.jpg', group.keys())
 
 
 class ThumbnailTest(zeit.cms.testing.FunctionalTestCase):

--- a/src/zeit/content/image/browser/tests/test_variant.py
+++ b/src/zeit/content/image/browser/tests/test_variant.py
@@ -175,8 +175,7 @@ class VariantIntegrationTest(zeit.cms.testing.SeleniumTestCase):
     def test_integration(self):
         """Open Image group and change settings of master and a variant."""
         s = self.selenium
-        self.open('/repository/2007/03/group')
-        s.click('link=Variants')
+        self.open('/repository/2007/03/group/variant.html')
         s.waitForCssCount('css=#variant-content', 1)  # wait for tab to load
 
         # test that descriptive name is displayed near image

--- a/src/zeit/content/image/image.py
+++ b/src/zeit/content/image/image.py
@@ -21,7 +21,7 @@ import zope.security.proxy
 
 class Image(zope.app.file.image.Image,
             zope.app.container.contained.Contained):
-    """Image contanis exactly one image."""
+    """Image contains exactly one image."""
 
     zope.interface.implements(zeit.content.image.interfaces.IImage)
     uniqueId = None
@@ -85,7 +85,7 @@ class TemporaryImage(LocalImage):
 @zope.component.adapter(RepositoryImage)
 @zope.interface.implementer(zeit.cms.workingcopy.interfaces.ILocalContent)
 def localimage_factory(context):
-    local= LocalImage(context.uniqueId, context.mimeType)
+    local = LocalImage(context.uniqueId, context.mimeType)
     local.__name__ = context.__name__
     zeit.cms.interfaces.IWebDAVProperties(local).update(
         zeit.cms.interfaces.IWebDAVProperties(context))

--- a/src/zeit/content/image/imagegroup.py
+++ b/src/zeit/content/image/imagegroup.py
@@ -156,7 +156,7 @@ class ImageGroupBase(object):
         image.__name__ = key
         image.__parent__ = self
         image.uniqueId = u'%s%s' % (self.uniqueId, key)
-        image.variant_source = source.uniqueId
+        image.variant_source = source.__name__
         return image
 
     def get_variant_size(self, key):

--- a/src/zeit/content/image/imagegroup.py
+++ b/src/zeit/content/image/imagegroup.py
@@ -32,7 +32,7 @@ class ImageGroupBase(object):
     zeit.cms.content.dav.mapProperties(
         zeit.content.image.interfaces.IImageGroup,
         zeit.content.image.interfaces.IMAGE_NAMESPACE,
-        ('master_image',))
+        ('master_images',))
 
     _variants = zeit.cms.content.dav.DAVProperty(
         zeit.content.image.interfaces.IImageGroup['variants'],
@@ -49,6 +49,11 @@ class ImageGroupBase(object):
     @variants.setter
     def variants(self, value):
         self._variants = value
+
+    @property
+    def master_image(self):
+        """Return first image of `master_images` as default master image."""
+        return self.master_images[0][1] if self.master_images else None
 
     def create_variant_image(self, key, source=None):
         """Retrieve Variant and create an image according to options in URL.

--- a/src/zeit/content/image/imagegroup.py
+++ b/src/zeit/content/image/imagegroup.py
@@ -42,7 +42,8 @@ class ImageGroupBase(object):
     zeit.cms.content.dav.mapProperties(
         zeit.content.image.interfaces.IImageGroup,
         IMAGE_NAMESPACE,
-        ('display_type',))
+        ('display_type',),
+        use_default=True)
 
     _master_images = zeit.cms.content.dav.DAVProperty(
         zeit.content.image.interfaces.IImageGroup['master_images'],

--- a/src/zeit/content/image/imagegroup.py
+++ b/src/zeit/content/image/imagegroup.py
@@ -50,10 +50,6 @@ class ImageGroupBase(object):
     def variants(self, value):
         self._variants = value
 
-    @property
-    def viewports(self):
-        return ['desktop', 'mobile']  # FIXME: retrieve from XML Source
-
     def create_variant_image(self, key, source=None):
         """Retrieve Variant and create an image according to options in URL.
 
@@ -137,9 +133,9 @@ class ImageGroupBase(object):
         return None
 
     def get_variant_viewport(self, key):
-        """If key contains `__mobile`, retrieve `mobile` else None."""
+        """If key contains `__mobile`, retrieve viewport `mobile` else None."""
         for segment in key.split('__')[1:]:
-            if segment in self.viewports:
+            if segment in zeit.content.image.interfaces.VIEWPORT_SOURCE(self):
                 return segment
         return None
 

--- a/src/zeit/content/image/imagegroup.py
+++ b/src/zeit/content/image/imagegroup.py
@@ -39,6 +39,11 @@ class ImageGroupBase(object):
 
     zope.interface.implements(zeit.content.image.interfaces.IImageGroup)
 
+    zeit.cms.content.dav.mapProperties(
+        zeit.content.image.interfaces.IImageGroup,
+        IMAGE_NAMESPACE,
+        ('infographic',))
+
     _master_images = zeit.cms.content.dav.DAVProperty(
         zeit.content.image.interfaces.IImageGroup['master_images'],
         IMAGE_NAMESPACE,

--- a/src/zeit/content/image/imagegroup.py
+++ b/src/zeit/content/image/imagegroup.py
@@ -5,7 +5,6 @@ import collections
 import grokcore.component as grok
 import lxml.objectify
 import persistent
-import re
 import sys
 import urlparse
 import z3c.traverser.interfaces

--- a/src/zeit/content/image/imagegroup.py
+++ b/src/zeit/content/image/imagegroup.py
@@ -51,7 +51,7 @@ class ImageGroupBase(object):
         self._variants = value
 
     @property
-    def breakpoints(self):
+    def viewports(self):
         return ['desktop', 'mobile']  # FIXME: retrieve from XML Source
 
     def create_variant_image(self, key, source=None):
@@ -64,10 +64,10 @@ class ImageGroupBase(object):
         variant = self.get_variant_by_key(key)
         size = self.get_variant_size(key)
         fill = self.get_variant_fill(key)
-        breakpoint = self.get_variant_breakpoint(key)
+        viewport = self.get_variant_viewport(key)
 
         # Make sure no invalid or redundant modifiers were provided
-        values = [variant.name, size, fill, breakpoint]
+        values = [variant.name, size, fill, viewport]
         if len([x for x in values if x]) != len(key.split('__')):
             raise KeyError(key)
 
@@ -136,10 +136,10 @@ class ImageGroupBase(object):
                     continue
         return None
 
-    def get_variant_breakpoint(self, key):
+    def get_variant_viewport(self, key):
         """If key contains `__mobile`, retrieve `mobile` else None."""
         for segment in key.split('__')[1:]:
-            if segment in self.breakpoints:
+            if segment in self.viewports:
                 return segment
         return None
 

--- a/src/zeit/content/image/imagegroup.py
+++ b/src/zeit/content/image/imagegroup.py
@@ -112,6 +112,12 @@ class ImageGroupBase(object):
                     if size is None:
                         size = source.getImageSize()
 
+        # Prefer a master image that was configured for given viewport.
+        elif source is None and viewport is not None:
+            for view, name in self.master_images:
+                if viewport == view:
+                    source = repository[name]
+
         # Our default transformation source should be the master image.
         if source is None:
             source = zeit.content.image.interfaces.IMasterImage(self, None)
@@ -136,6 +142,7 @@ class ImageGroupBase(object):
         image.__name__ = key
         image.__parent__ = self
         image.uniqueId = u'%s%s' % (self.uniqueId, key)
+        image.variant_source = source.uniqueId
         return image
 
     def get_variant_size(self, key):

--- a/src/zeit/content/image/imagegroup.py
+++ b/src/zeit/content/image/imagegroup.py
@@ -275,6 +275,7 @@ class ImageGroup(ImageGroupBase,
         * /imagegroup/zon-large
         * /imagegroup/zon-large__200x200
         * /imagegroup/zon-large__200x200__0000ff
+        * /imagegroup/zon-large__200x200__0000ff__mobile
 
         JSON API:
         * /imagegroup/variants/zon-large

--- a/src/zeit/content/image/imagegroup.py
+++ b/src/zeit/content/image/imagegroup.py
@@ -42,7 +42,7 @@ class ImageGroupBase(object):
     zeit.cms.content.dav.mapProperties(
         zeit.content.image.interfaces.IImageGroup,
         IMAGE_NAMESPACE,
-        ('infographic',))
+        ('display_type',))
 
     _master_images = zeit.cms.content.dav.DAVProperty(
         zeit.content.image.interfaces.IImageGroup['master_images'],

--- a/src/zeit/content/image/interfaces.py
+++ b/src/zeit/content/image/interfaces.py
@@ -162,6 +162,13 @@ class MasterImageSource(
             yield name
 
 
+class DisplayTypeSource(zeit.cms.content.sources.XMLSource):
+
+    product_configuration = 'zeit.content.image'
+    config_url = 'display-type-source'
+    attribute = 'id'
+
+
 class ViewportSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.image'
@@ -223,8 +230,11 @@ class IImageGroup(zeit.cms.repository.interfaces.ICollection,
     variants = zope.schema.Dict(
         title=_('Setting for variants'))
 
-    infographic = zope.schema.Bool(
-        title=_(u'True if image group should be rendered as infographic'))
+    display_type = zope.schema.Choice(
+        title=_("Display Type"),
+        source=DisplayTypeSource(),
+        default='imagegroup',
+        required=True)
 
     def variant_url(name, width=None, height=None, fill_color=None,
                     thumbnail=False):

--- a/src/zeit/content/image/interfaces.py
+++ b/src/zeit/content/image/interfaces.py
@@ -49,6 +49,11 @@ class IImageMetadata(zope.interface.Interface):
         max=53,
         required=False)
 
+    origin = zope.schema.TextLine(
+        title=_("Origin"),
+        default=u'',
+        required=False)
+
     copyrights = zope.schema.Tuple(
         title=_("Copyrights"),
         default=((u'©', None, False),),
@@ -217,6 +222,9 @@ class IImageGroup(zeit.cms.repository.interfaces.ICollection,
 
     variants = zope.schema.Dict(
         title=_('Setting for variants'))
+
+    infographic = zope.schema.Bool(
+        title=_(u'True if image group should be rendered as infographic'))
 
     def variant_url(name, width=None, height=None, fill_color=None,
                     thumbnail=False):

--- a/src/zeit/content/image/interfaces.py
+++ b/src/zeit/content/image/interfaces.py
@@ -2,6 +2,7 @@
 from zeit.cms.i18n import MessageFactory as _
 import PIL.Image
 import zc.form.field
+import zc.form.interfaces
 import zc.sourcefactory.contextual
 import zeit.cms.content.contentsource
 import zeit.cms.content.interfaces
@@ -9,6 +10,7 @@ import zeit.cms.interfaces
 import zeit.cms.repository.interfaces
 import zeit.cms.workingcopy.interfaces
 import zope.file.interfaces
+import zope.interface
 import zope.schema
 
 
@@ -143,6 +145,11 @@ class MasterImageSource(
         zc.sourcefactory.contextual.BasicContextualSourceFactory):
 
     def getValues(self, context):
+        """List names of images inside ImageGroup."""
+        # Sadly zc.form.field.Combination does not bind it's field to the right
+        # context, thus fix the context if necessary.
+        if zc.form.interfaces.ICombinationField.providedBy(context):
+            context = context.context
         repository = zope.component.getUtility(
             zeit.cms.repository.interfaces.IRepository)
         for name in repository.getContent(context.uniqueId):
@@ -163,9 +170,20 @@ class IImageGroup(zeit.cms.repository.interfaces.ICollection,
                   zeit.cms.repository.interfaces.IDAVContent):
     """An image group groups images with the same motif together."""
 
-    master_image = zope.schema.Choice(
-        title=_('Master image'),
-        source=MasterImageSource())
+    master_image = zope.interface.Attribute('Name of the master image')
+
+    master_images = zope.schema.Tuple(
+        title=_('Mapping of viewport to master image'),
+        unique=True,
+        min_length=1,
+        missing_value=(),
+        value_type=zc.form.field.Combination(
+            (zope.schema.Choice(
+                title=_('Viewport'),
+                source=VIEWPORT_SOURCE),
+             zope.schema.Choice(
+                 title=_('Master image'),
+                 source=MasterImageSource()))))
 
     variants = zope.schema.Dict(
         title=_('Setting for variants'))

--- a/src/zeit/content/image/interfaces.py
+++ b/src/zeit/content/image/interfaces.py
@@ -149,6 +149,15 @@ class MasterImageSource(
             yield name
 
 
+class ViewportSource(zeit.cms.content.sources.XMLSource):
+
+    product_configuration = 'zeit.content.image'
+    config_url = 'viewport-source'
+    attribute = 'id'
+
+VIEWPORT_SOURCE = ViewportSource()
+
+
 class IImageGroup(zeit.cms.repository.interfaces.ICollection,
                   zeit.cms.interfaces.IAsset,
                   zeit.cms.repository.interfaces.IDAVContent):

--- a/src/zeit/content/image/interfaces.py
+++ b/src/zeit/content/image/interfaces.py
@@ -212,7 +212,7 @@ class IImageGroup(zeit.cms.repository.interfaces.ICollection,
                 title=_('Viewport'),
                 source=VIEWPORT_SOURCE),
              zope.schema.Choice(
-                 title=_('Master image'),
+                 title=_('Image'),
                  source=MasterImageSource()))))
 
     variants = zope.schema.Dict(

--- a/src/zeit/content/image/metadata.py
+++ b/src/zeit/content/image/metadata.py
@@ -95,6 +95,7 @@ class XMLReferenceUpdater(zeit.cms.content.xmlsupport.XMLReferenceUpdater):
             else:
                 entry.attrib.pop(name, None)
 
+        set_attribute('origin', context.origin)
         set_attribute('title', context.title)
         set_attribute('alt', context.alt)
 

--- a/src/zeit/content/image/metadata.py
+++ b/src/zeit/content/image/metadata.py
@@ -15,7 +15,7 @@ class ImageMetadata(object):
     zeit.cms.content.dav.mapProperties(
         zeit.content.image.interfaces.IImageMetadata,
         zeit.content.image.interfaces.IMAGE_NAMESPACE,
-        ('alt', 'caption', 'links_to'))
+        ('alt', 'caption', 'links_to', 'origin'))
     zeit.cms.content.dav.mapProperties(
         zeit.content.image.interfaces.IImageMetadata,
         'http://namespaces.zeit.de/CMS/document',

--- a/src/zeit/content/image/testing.py
+++ b/src/zeit/content/image/testing.py
@@ -77,7 +77,7 @@ def create_image_group_with_master_image(file_name=None):
     extension = os.path.splitext(file_name)[-1].lower()
 
     group = zeit.content.image.imagegroup.ImageGroup()
-    group.master_image = u'master-image' + extension
+    group.master_images = (('desktop', u'master-image' + extension),)
     repository['group'] = group
     image = zeit.content.image.image.LocalImage()
     image.mimeType = mimetypes.types_map[extension]

--- a/src/zeit/content/image/testing.py
+++ b/src/zeit/content/image/testing.py
@@ -15,6 +15,7 @@ import zope.component
 product_config = """
 <product-config zeit.content.image>
     viewport-source file://{here}/tests/fixtures/viewports.xml
+    display-type-source file://{here}/tests/fixtures/display-types.xml
     variant-source file://{here}/tests/fixtures/variants.xml
     legacy-variant-source file://{here}/tests/fixtures/legacy-variants.xml
 </product-config>

--- a/src/zeit/content/image/testing.py
+++ b/src/zeit/content/image/testing.py
@@ -14,6 +14,7 @@ import zope.component
 
 product_config = """
 <product-config zeit.content.image>
+    viewport-source file://{here}/tests/fixtures/viewports.xml
     variant-source file://{here}/tests/fixtures/variants.xml
     legacy-variant-source file://{here}/tests/fixtures/legacy-variants.xml
 </product-config>

--- a/src/zeit/content/image/tests/fixtures/display-types.xml
+++ b/src/zeit/content/image/tests/fixtures/display-types.xml
@@ -1,0 +1,4 @@
+<display-types>
+  <display-type id="imagegroup">Bildergruppe</display-type>
+  <display-type id="infographic">Infografik</display-type>
+</display-types>

--- a/src/zeit/content/image/tests/fixtures/viewports.xml
+++ b/src/zeit/content/image/tests/fixtures/viewports.xml
@@ -1,0 +1,4 @@
+<viewports>
+  <viewport id="desktop">Desktop</viewport>
+  <viewport id="mobile">Mobil</viewport>
+</viewports>

--- a/src/zeit/content/image/tests/test_imagegroup.py
+++ b/src/zeit/content/image/tests/test_imagegroup.py
@@ -66,7 +66,7 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
         self.assertNotEqual(master_sample, materialized_sample)
         self.assertEqual((80, 80), materialized.size)
 
-    def test_getitem_handles_breakpoint_modifier(self):
+    def test_getitem_handles_viewport_modifier(self):
         with self.assertNothingRaised():
             self.group['square__mobile']
 

--- a/src/zeit/content/image/tests/test_imagegroup.py
+++ b/src/zeit/content/image/tests/test_imagegroup.py
@@ -70,6 +70,47 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
         with self.assertNothingRaised():
             self.group['square__mobile']
 
+    def test_getitem_defines_no_variant_source_for_materialized_files(self):
+        """It raises AttributeError when asked for `variant_source`.
+
+        Since `variant_source` is used for testing only, we do not want to add
+        it to `BaseImage`. Thus only variants created using
+        `ImageGroupBase.create_variant_image` should have this attribute.
+
+        """
+        image = self.group['master-image.jpg']
+        with self.assertRaises(AttributeError):
+            image.variant_source
+
+    def test_getitem_uses_primary_master_image_if_no_viewport_was_given(self):
+        image = self.group['square']
+        self.assertEqual(
+            'http://xml.zeit.de/group/master-image.jpg', image.variant_source)
+
+    def test_getitem_uses_primary_master_image_if_viewport_not_configured(
+            self):
+        """Default configuration only includes `desktop`, but not `mobile`."""
+        image = self.group['square__mobile']
+        self.assertEqual(
+            'http://xml.zeit.de/group/master-image.jpg', image.variant_source)
+
+    def test_getitem_chooses_master_image_using_given_viewport(self):
+        """Uses master-image for desktop and master-image-mobile for mobile."""
+        self.group['master-image-mobile.jpg'] = create_local_image(
+            'obama-clinton-120x120.jpg')
+        with mock.patch(
+                'zeit.content.image.imagegroup.ImageGroupBase.master_images',
+                new_callable=mock.PropertyMock) as master_images:
+            master_images.return_value = (
+                ('desktop', 'master-image.jpg'),
+                ('mobile', 'master-image-mobile.jpg'))
+            self.assertEqual(
+                'http://xml.zeit.de/group/master-image.jpg',
+                self.group['square__desktop'].variant_source)
+            self.assertEqual(
+                'http://xml.zeit.de/group/master-image-mobile.jpg',
+                self.group['square__mobile'].variant_source)
+
     def test_getitem_raises_keyerror_if_variant_does_not_exist(self):
         with self.assertRaises(KeyError):
             self.group['nonexistent']

--- a/src/zeit/content/image/tests/test_imagegroup.py
+++ b/src/zeit/content/image/tests/test_imagegroup.py
@@ -84,15 +84,13 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
 
     def test_getitem_uses_primary_master_image_if_no_viewport_was_given(self):
         image = self.group['square']
-        self.assertEqual(
-            'http://xml.zeit.de/group/master-image.jpg', image.variant_source)
+        self.assertEqual('master-image.jpg', image.variant_source)
 
     def test_getitem_uses_primary_master_image_if_viewport_not_configured(
             self):
         """Default configuration only includes `desktop`, but not `mobile`."""
         image = self.group['square__mobile']
-        self.assertEqual(
-            'http://xml.zeit.de/group/master-image.jpg', image.variant_source)
+        self.assertEqual('master-image.jpg', image.variant_source)
 
     def test_getitem_chooses_master_image_using_given_viewport(self):
         """Uses master-image for desktop and master-image-mobile for mobile."""
@@ -105,10 +103,10 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
                 ('desktop', 'master-image.jpg'),
                 ('mobile', 'master-image-mobile.jpg'))
             self.assertEqual(
-                'http://xml.zeit.de/group/master-image.jpg',
+                'master-image.jpg',
                 self.group['square__desktop'].variant_source)
             self.assertEqual(
-                'http://xml.zeit.de/group/master-image-mobile.jpg',
+                'master-image-mobile.jpg',
                 self.group['square__mobile'].variant_source)
 
     def test_getitem_raises_keyerror_if_variant_does_not_exist(self):

--- a/src/zeit/content/image/tests/test_imagegroup.py
+++ b/src/zeit/content/image/tests/test_imagegroup.py
@@ -133,3 +133,19 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
                 Variant(name='foo', id='small', max_size='100x100')]):
             self.assertEqual(
                 None, self.group.get_variant_by_size('foo__9999x9999'))
+
+    def test_master_image_is_None_if_no_master_images_defined(self):
+        group = zeit.content.image.imagegroup.ImageGroup()
+        self.assertEqual(None, group.master_image)
+
+    def test_master_image_retrieves_first_image_from_master_images(self):
+        group = zeit.content.image.imagegroup.ImageGroup()
+        group.master_images = (('viewport', 'master.png'),)
+        self.assertEqual('master.png', group.master_image)
+
+    def test_master_image_is_retrieved_from_DAV_properties_for_bw_compat(self):
+        from zeit.content.image.interfaces import IMAGE_NAMESPACE
+        group = zeit.content.image.imagegroup.ImageGroup()
+        properties = zeit.connector.interfaces.IWebDAVReadProperties(group)
+        properties[('master_image', IMAGE_NAMESPACE)] = 'master.png'
+        self.assertEqual('master.png', group.master_image)

--- a/src/zeit/content/image/tests/test_imagegroup.py
+++ b/src/zeit/content/image/tests/test_imagegroup.py
@@ -66,6 +66,10 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
         self.assertNotEqual(master_sample, materialized_sample)
         self.assertEqual((80, 80), materialized.size)
 
+    def test_getitem_handles_breakpoint_modifier(self):
+        with self.assertNothingRaised():
+            self.group['square__mobile']
+
     def test_getitem_raises_keyerror_if_variant_does_not_exist(self):
         with self.assertRaises(KeyError):
             self.group['nonexistent']

--- a/src/zeit/content/image/tests/test_interfaces.py
+++ b/src/zeit/content/image/tests/test_interfaces.py
@@ -1,0 +1,27 @@
+import unittest
+
+
+class TestUniqueViewportAndMasterImageConstraint(unittest.TestCase):
+
+    def test_succeeds_for_empty_tuple(self):
+        from ..interfaces import unique_viewport_and_master_image
+        self.assertEqual(True, unique_viewport_and_master_image(()))
+
+    def test_succeeds_for_unique_combinations(self):
+        from ..interfaces import unique_viewport_and_master_image
+        self.assertEqual(True, unique_viewport_and_master_image(
+            (('desktop', 'image1'), ('mobile', 'image2'))))
+
+    def test_raises_DuplicateViewport_if_viewport_is_used_multiple_times(self):
+        from ..interfaces import DuplicateViewport
+        from ..interfaces import unique_viewport_and_master_image
+        with self.assertRaises(DuplicateViewport):
+            unique_viewport_and_master_image(
+                (('desktop', 'image1'), ('desktop', 'image2')))
+
+    def test_raises_DuplicateImage_if_masterimage_is_used_multiple_times(self):
+        from ..interfaces import DuplicateImage
+        from ..interfaces import unique_viewport_and_master_image
+        with self.assertRaises(DuplicateImage):
+            unique_viewport_and_master_image(
+                (('desktop', 'image'), ('mobile', 'image')))


### PR DESCRIPTION
An image group should be able to display different images, depending on a new modifier `viewport`. Allowed values are described by http://cms-backend.zeit.de:9000/cms/work/data/image-viewports.xml.
