### PR TITLE
ZON-1586: Proxy image reference attribute access to target

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ zeit.content.image changes
 2.15.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Proxy image reference attribute access to its target and ignore
+  copied metadata (unless, of cause the attribute is overriden locally).
+  We still copy the XML on creation and update for compatibility. (Re ZON-1586)
 
 
 2.15.0 (2016-08-10)

--- a/src/zeit/content/image/tests/test_imagereference.py
+++ b/src/zeit/content/image/tests/test_imagereference.py
@@ -42,12 +42,26 @@ class ImageReferenceTest(zeit.cms.testing.FunctionalTestCase):
         content.images = (ref,)
         ref.title = u'localtitle'
         ref.caption = u'localcaption'
-        self.assertEqual('localtitle', ref.xml.get('title'))
-        self.assertEqual('localcaption', ref.xml.bu)
-
+        self.assertEqual('localtitle', ref.title)
+        self.assertEqual('localcaption', ref.caption)
         ref.update_metadata()
-        self.assertEqual('localtitle', ref.xml.get('title'))
-        self.assertEqual('localcaption', ref.xml.bu)
+        self.assertEqual('localtitle', ref.title)
+        self.assertEqual('localcaption', ref.caption)
+
+    def test_not_overridable_values_are_always_proxied_to_target(self):
+        image = ICMSContent('http://xml.zeit.de/2006/DSC00109_2.JPG')
+        with checked_out(image) as co:
+            IImageMetadata(co).origin = 'originalorigin'
+        content = self.repository['testcontent']
+        ref = content.images.create(image)
+        content.images = (ref,)
+        self.assertEqual('originalorigin', ref.origin)
+        ref.update_metadata()
+        self.assertEqual('originalorigin', ref.origin)
+        with checked_out(ref.target) as co:
+            IImageMetadata(co).origin = 'updatedorigin'
+        ref.update_metadata()
+        self.assertEqual('updatedorigin', ref.origin)
 
     def test_empty_local_values_leave_original_ones_alone(self):
         image = ICMSContent('http://xml.zeit.de/2006/DSC00109_2.JPG')
@@ -57,11 +71,11 @@ class ImageReferenceTest(zeit.cms.testing.FunctionalTestCase):
         content = self.repository['testcontent']
         ref = content.images.create(image)
         content.images = (ref,)
-        self.assertEqual('originaltitle', ref.xml.get('title'))
-        self.assertEqual('originalcaption', ref.xml.bu)
+        self.assertEqual('originaltitle', ref.title)
+        self.assertEqual('originalcaption', ref.caption)
         ref.update_metadata()
-        self.assertEqual('originaltitle', ref.xml.get('title'))
-        self.assertEqual('originalcaption', ref.xml.bu)
+        self.assertEqual('originaltitle', ref.title)
+        self.assertEqual('originalcaption', ref.caption)
 
     def test_setting_local_value_none_yields_none(self):
         image = ICMSContent('http://xml.zeit.de/2006/DSC00109_2.JPG')


### PR DESCRIPTION
ImageReference claims to implement IImageMetadata but up until now did not. We now proxy attributes that are not locally overridden to the reference target. By overwriting the attribute-getter (and not the individual ones) we have the freedom to further extend image metadata and groups without having to worry about breaking the interface compliance of the reference.

(chose **getattribute** over **getattr** because the reference updater may write attributes to the instance **dict** which we want to ignore)
