### PR TITLE
ZON-3363: Enhance Imagegroup Handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,14 +4,9 @@ zeit.content.image changes
 2.17.2 (unreleased)
 -------------------
 
-- ZON-3363: Display ``view.html`` instead of ``variant.html`` when creating an
-  ``ImageGroup`` whose ``display_type`` is ``infographic``.
-
-- ZON-3363: Hide edit menu for Infographics.
+- ZON-3363: Some UI/form field tweaks for infographics.
 
 - ZON-3363: Hide thumbnails in content listing of ``ImageGroup``.
-
-- ZON-3363: Only display ``origin`` field for Infographics.
 
 
 2.17.1 (2016-10-05)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,8 @@ zeit.content.image changes
 
 - ZON-3363: Hide thumbnails in content listing of ``ImageGroup``.
 
+- ZON-3363: Only display ``origin`` field for Infographics.
+
 
 2.17.1 (2016-10-05)
 -------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ zeit.content.image changes
 2.17.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-3363: Display ``view.html`` instead of ``variant.html`` when creating an
+  ``ImageGroup`` whose ``display_type`` is ``infographic``.
 
 
 2.17.1 (2016-10-05)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ zeit.content.image changes
 
 - ZON-3363: Hide edit menu for Infographics.
 
+- ZON-3363: Hide thumbnails in content listing of ``ImageGroup``.
+
 
 2.17.1 (2016-10-05)
 -------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ zeit.content.image changes
 - ZON-3363: Display ``view.html`` instead of ``variant.html`` when creating an
   ``ImageGroup`` whose ``display_type`` is ``infographic``.
 
+- ZON-3363: Hide edit menu for Infographics.
+
 
 2.17.1 (2016-10-05)
 -------------------

--- a/src/zeit/content/image/browser/configure.zcml
+++ b/src/zeit/content/image/browser/configure.zcml
@@ -314,8 +314,18 @@
     name="variant.html"
     class=".variant.Editor"
     template="image-variants.pt"
-    menu="zeit-context-views" title="Edit"
     permission="zope.View"
+    />
+
+  <browser:menuItem
+    zcml:condition="have zeit.content.image.variants"
+    for="zeit.content.image.interfaces.IRepositoryImageGroup"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    action="@@variant.html"
+    menu="zeit-context-views"
+    title="Edit"
+    permission="zope.View"
+    filter="python:context.display_type != modules['zeit.content.image.interfaces'].INFOGRAPHIC_DISPLAY_TYPE"
     />
 
 

--- a/src/zeit/content/image/browser/imagegroup.py
+++ b/src/zeit/content/image/browser/imagegroup.py
@@ -1,5 +1,6 @@
 from zeit.cms.i18n import MessageFactory as _
 from zeit.content.image.browser.interfaces import IMasterImageUploadSchema
+from zeit.content.image.interfaces import INFOGRAPHIC_DISPLAY_TYPE
 from zope.formlib.widget import CustomWidgetFactory
 import gocept.form.grouped
 import itertools
@@ -90,6 +91,8 @@ class AddForm(FormBase,
 
     @property
     def next_view(self):
+        if self._created_object.display_type == INFOGRAPHIC_DISPLAY_TYPE:
+            return 'view.html'
         if zope.app.appsetup.appsetup.getConfigContext().hasFeature(
                 'zeit.content.image.variants'):
             return 'variant.html'

--- a/src/zeit/content/image/browser/imagegroup.py
+++ b/src/zeit/content/image/browser/imagegroup.py
@@ -157,6 +157,13 @@ class View(zeit.cms.browser.listing.Listing):
         zeit.cms.browser.listing.MetadataColumn(u'Metadaten', name='metadata'),
     )
 
+    def filter_content(self, obj):
+        """Do not display thumbnail images."""
+        prefix = zeit.content.image.imagegroup.Thumbnails.SOURCE_IMAGE_PREFIX
+        if obj.__name__.startswith(prefix):
+            return False
+        return super(View, self).filter_content(obj)
+
 
 class AddImage(zeit.content.image.browser.form.AddForm):
 

--- a/src/zeit/content/image/browser/resources.py
+++ b/src/zeit/content/image/browser/resources.py
@@ -13,6 +13,8 @@ Resource('variant.js', depends=[
     variant_css, zeit.cms.browser.resources.base,
     backbone, cropper, handlebars])
 
+Resource('form.js', depends=[zeit.cms.browser.resources.base])
+
 test_lib = fanstatic.Library('zeit.content.image.test', 'tests')
 test_variant_js = fanstatic.Resource(
     test_lib, 'test_variant.js', depends=[variant_js])

--- a/src/zeit/content/image/browser/resources/form.js
+++ b/src/zeit/content/image/browser/resources/form.js
@@ -1,0 +1,47 @@
+/*global window,zeit,document*/
+(function() {
+    "use strict";
+
+    var $ = window.jQuery;
+
+    var get_display_type = function () {
+        // In read-only mode the widget contains no select, but the selected
+        // option as text.
+        var type, widget;
+        widget = $('.fieldname-display_type .widget');
+        if (widget.find('select').length) {
+            type = widget.find('select option:selected').text();
+        } else {
+            type = widget.text();
+        }
+        return type;
+    };
+
+    var update_origin_visibility = function () {
+        // Hide `origin` field unless `display_type` is `Infografik`.
+        var type = get_display_type();
+        if (type === 'Infografik') {
+            $('.fieldname-origin').show();
+        } else {
+            $('.fieldname-origin').hide();
+        }
+    };
+
+    $(document).ready(function() {
+        if (!$('fieldset.image-form').length) {
+            return;
+        }
+
+        // set initial visibility on load
+        update_origin_visibility();
+
+        // update visibility on change, unless we are in read-only mode
+        var widget = $('.fieldname-display_type .widget');
+        if (widget.find('select').length) {
+            widget.find('select').on('change', function () {
+                update_origin_visibility();
+            });
+        }
+    });
+
+})();

--- a/src/zeit/content/image/browser/tests/test_imagegroup.py
+++ b/src/zeit/content/image/browser/tests/test_imagegroup.py
@@ -186,6 +186,24 @@ class ImageGroupBrowserTest(
         self.save_imagegroup()
         self.assertEndsWith('@@view.html', self.browser.url)
 
+    def test_display_type_imagegroup_shows_edit_tab(self):
+        self.add_imagegroup()
+        self.set_imagegroup_filename('infographic')
+        self.fill_copyright_information()
+        self.set_display_type('Bildergruppe')
+        self.save_imagegroup()
+        self.assertIn('repository/2006/infographic/@@variant.html',
+                      self.browser.contents)
+
+    def test_display_type_infographic_hides_edit_tab(self):
+        self.add_imagegroup()
+        self.set_imagegroup_filename('infographic')
+        self.fill_copyright_information()
+        self.set_display_type('Infografik')
+        self.save_imagegroup()
+        self.assertNotIn('repository/2006/infographic/@@variant.html',
+                         self.browser.contents)
+
 
 class ThumbnailTest(zeit.cms.testing.FunctionalTestCase):
 

--- a/src/zeit/content/image/browser/tests/test_imagegroup.py
+++ b/src/zeit/content/image/browser/tests/test_imagegroup.py
@@ -192,6 +192,32 @@ class ImageGroupBrowserTest(
             'repository/imagegroup/@@variant.html', self.browser.contents)
 
 
+class ImageGroupWebdriverTest(zeit.cms.testing.SeleniumTestCase):
+
+    layer = zeit.content.image.testing.WEBDRIVER_LAYER
+
+    def setUp(self):
+        super(ImageGroupWebdriverTest, self).setUp()
+        create_image_group_with_master_image()
+
+    def test_visibility_of_origin_field_depends_on_display_type(self):
+        sel = self.selenium
+        origin = 'css=.fieldname-origin'
+        display_type = 'css=#form\.display_type'
+        sel.open('/repository/group/@@checkout')
+
+        sel.select(display_type, 'label=Infografik')
+        sel.assertVisible(origin)
+
+        sel.select(display_type, 'label=Bildergruppe')
+        sel.assertNotVisible(origin)
+
+    def test_origin_field_is_hidden_in_read_only_mode_if_not_infographic(self):
+        sel = self.selenium
+        sel.open('/repository/group/@@metadata.html')
+        sel.assertNotVisible('css=.fieldname-origin')
+
+
 class ThumbnailTest(zeit.cms.testing.FunctionalTestCase):
 
     layer = zeit.content.image.testing.ZCML_LAYER

--- a/src/zeit/content/image/browser/tests/test_imagegroup.py
+++ b/src/zeit/content/image/browser/tests/test_imagegroup.py
@@ -1,4 +1,5 @@
 from zeit.content.image.testing import create_image_group_with_master_image
+import gocept.testing.assertion
 import mock
 import pkg_resources
 import zeit.cms.testing
@@ -22,6 +23,9 @@ class ImageGroupHelperMixin(object):
 
     def set_imagegroup_title(self, title):
         self.browser.getControl('Image title').value = title
+
+    def set_display_type(self, display_type):
+        self.browser.getControl('Display Type').displayValue = [display_type]
 
     def fill_copyright_information(self):
         b = self.browser
@@ -91,7 +95,8 @@ class ImageGroupPublishTest(zeit.cms.testing.BrowserTestCase):
 
 class ImageGroupBrowserTest(
         zeit.cms.testing.BrowserTestCase,
-        ImageGroupHelperMixin):
+        ImageGroupHelperMixin,
+        gocept.testing.assertion.String):
 
     layer = zeit.content.image.testing.ZCML_LAYER
 
@@ -164,6 +169,22 @@ class ImageGroupBrowserTest(
         with zeit.cms.testing.site(self.getRootFolder()):
             group = self.repository['2006']['image-group']
         self.assertIn('thumbnail-source-master-image.jpg', group)
+
+    def test_display_type_imagegroup_opens_variant_html_on_save(self):
+        self.add_imagegroup()
+        self.set_imagegroup_filename('imagegroup')
+        self.fill_copyright_information()
+        self.set_display_type('Bildergruppe')
+        self.save_imagegroup()
+        self.assertEndsWith('@@variant.html', self.browser.url)
+
+    def test_display_type_infographic_opens_view_html_on_save(self):
+        self.add_imagegroup()
+        self.set_imagegroup_filename('infographic')
+        self.fill_copyright_information()
+        self.set_display_type('Infografik')
+        self.save_imagegroup()
+        self.assertEndsWith('@@view.html', self.browser.url)
 
 
 class ThumbnailTest(zeit.cms.testing.FunctionalTestCase):


### PR DESCRIPTION
Die restlichen Aufgaben vom Ticket waren aufwändiger und haben nicht in den aktuellen Sprint gepasst. Die kleineren Anpassungen können wir aber ja trotzdem schon mergen.
