### PR TITLE
ZON-3174: Extend copyright field to include company, add external_id

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.content.image changes
 ==========================
 
-2.19.2 (unreleased)
+2.20.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-3174: Extend copyright field to include company (dropdown and freetext)
 
 
 2.19.1 (2017-06-21)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ zeit.content.image changes
 2.20.0 (unreleased)
 -------------------
 
-- ZON-3174: Extend copyright field to include company (dropdown and freetext)
+- ZON-3174: Extend copyright field to include company (dropdown and freetext),
+  add field for external ID
 
 
 2.19.1 (2017-06-21)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.content.image',
-    version='2.19.2.dev0',
+    version='2.20.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/content/image/README.txt
+++ b/src/zeit/content/image/README.txt
@@ -140,7 +140,7 @@ Set metadata:
 The interface default for the copyright is:
 
 >>> zeit.content.image.interfaces.IImageMetadata['copyrights'].default
-((u'\xa9', None, False),)
+((u'\xa9', None, None, None, False),)
 
 
 Make sure we don't die when there is an invalid XML snippet stored:

--- a/src/zeit/content/image/browser/README.txt
+++ b/src/zeit/content/image/browser/README.txt
@@ -80,8 +80,6 @@ copyright is filled with the default value though:
 
 >>> browser.getControl(name='form.copyrights.0..combination_00').value
 '\xc2\xa9'
->>> browser.getControl(name='form.copyrights.0..combination_01').value
-''
 
 Fill out some values:
 
@@ -99,7 +97,7 @@ Fill out some values:
 >>> browser.getControl('Links to').value = 'http://www.zeit.de'
 >>> browser.getControl(name='form.copyrights.0..combination_00').value = (
 ...     'ZEIT ONLINE')
->>> browser.getControl(name='form.copyrights.0..combination_01').value = (
+>>> browser.getControl(name='form.copyrights.0..combination_03').value = (
 ...     'http://www.zeit.de/')
 >>> browser.getControl('Apply').click()
 >>> 'There where errors' in browser.contents
@@ -178,7 +176,7 @@ Make sure the image is not changed by looking at the image view:
   ...
   <ol class="image-copyrights">
     <li>
-      ZEIT ONLINE
+      ZEIT ONLINE / -
       (<a href="http://www.zeit.de/">http://www.zeit.de/</a>)
     </li>
   </ol>...
@@ -226,8 +224,6 @@ The image file is required:
 
 >>> browser.getControl(name='form.copyrights.0..combination_00').value = (
 ...     'ZEIT ONLINE')
->>> browser.getControl(name='form.copyrights.0..combination_01').value = (
-...     'http://www.zeit.de/')
 >>> browser.getControl(name='form.actions.add').click()
 >>> print browser.contents
 <...
@@ -344,8 +340,6 @@ Lets create an image group:
 >>> browser.getControl('Image title').value = 'New Hampshire'
 >>> browser.getControl(name='form.copyrights.0..combination_00').value = (
 ...     'ZEIT ONLINE')
->>> browser.getControl(name='form.copyrights.0..combination_01').value = (
-...     'http://www.zeit.de/')
 >>> set_file_data('opernball.jpg', 'master_image_blobs.0.')
 >>> browser.getControl(name='form.actions.add').click()
 

--- a/src/zeit/content/image/browser/README.txt
+++ b/src/zeit/content/image/browser/README.txt
@@ -99,6 +99,7 @@ Fill out some values:
 ...     'ZEIT ONLINE')
 >>> browser.getControl(name='form.copyrights.0..combination_03').value = (
 ...     'http://www.zeit.de/')
+>>> browser.getControl('External company ID').value = 'externalid'
 >>> browser.getControl('Apply').click()
 >>> 'There where errors' in browser.contents
 False
@@ -109,6 +110,8 @@ Verify some values:
 'Opernball'
 >>> browser.getControl(name='form.year').value
 '2007'
+>>> browser.getControl('External company ID').value
+'externalid'
 
 Let's verify get the right file data back from the image:
 

--- a/src/zeit/content/image/browser/copyright.txt
+++ b/src/zeit/content/image/browser/copyright.txt
@@ -26,7 +26,7 @@ Set a copyright which will be overwritten by the bulk change:
 
 >>> browser.getControl(name='form.copyrights.0..combination_00').value = (
 ...     'ZEIT ONLINE')
->>> browser.getControl(name='form.copyrights.0..combination_01').value = (
+>>> browser.getControl(name='form.copyrights.0..combination_03').value = (
 ...     'http://www.zeit.de/')
 >>> browser.getControl(name='form.actions.add').click()
 
@@ -54,12 +54,12 @@ Fill in two copyrights:
 
 >>> browser.getControl(name='form.copyrights.0..combination_00').value = (
 ...     'gocept')
->>> browser.getControl(name='form.copyrights.0..combination_01').value = (
+>>> browser.getControl(name='form.copyrights.0..combination_03').value = (
 ...     'http://www.gocept.com/')
 >>> browser.getControl('Add Copyrights').click()
 >>> browser.getControl(name='form.copyrights.1..combination_00').value = (
 ...     'Hans')
->>> browser.getControl(name='form.copyrights.1..combination_01').value = (
+>>> browser.getControl(name='form.copyrights.1..combination_03').value = (
 ...     'http://www.wurst.com/')
 >>> browser.getControl('Set copyrights').click()
 >>> print browser.contents
@@ -83,11 +83,11 @@ Let's see if that's correct:
 <?xml...
   <ol class="image-copyrights">
     <li>
-      gocept
+      gocept / -
       (<a href="http://www.gocept.com/">http://www.gocept.com/</a>)
     </li>
     <li>
-      Hans
+      Hans / -
       (<a href="http://www.wurst.com/">http://www.wurst.com/</a>)
     </li>
   </ol>
@@ -98,7 +98,7 @@ Let's see if that's correct:
 >>> browser.getLink('Metadata').click()
 >>> print browser.contents
 <?xml ...
-...gocept...
+...gocept
 ...<a href="http://www.gocept.com/">http://www.gocept.com/</a>
 ...
 ...Hans

--- a/src/zeit/content/image/browser/image.py
+++ b/src/zeit/content/image/browser/image.py
@@ -65,9 +65,12 @@ class ImageView(zeit.cms.browser.view.Base):
     @property
     def copyrights(self):
         result = []
-        for copyright, url, nofollow in self.metadata.copyrights:
+        for copyright, company, company_text, url, nofollow in \
+                self.metadata.copyrights:
             result.append(dict(
                 copyright=copyright,
+                company=company,
+                company_text=company_text,
                 url=url,
                 nofollow=nofollow))
         return result

--- a/src/zeit/content/image/browser/image_view.pt
+++ b/src/zeit/content/image/browser/image_view.pt
@@ -28,7 +28,8 @@
   
   <ol class="image-copyrights">
     <li tal:repeat="copyright view/copyrights">
-      <span tal:replace="copyright/copyright">ZEIT</span>
+      <span tal:replace="copyright/copyright">ZEIT</span> /
+      <span tal:replace="python: copyright['company_text'] or copyright['company'] or '-'">dpa</span>
       (<a tal:attributes="href copyright/url"
         tal:content="copyright/url">
         http://...

--- a/src/zeit/content/image/browser/master-image.txt
+++ b/src/zeit/content/image/browser/master-image.txt
@@ -14,8 +14,6 @@ group[#browser]_:
 >>> set_file_data('opernball.jpg')
 >>> browser.getControl(name='form.copyrights.0..combination_00').value = (
 ...     'ZEIT ONLINE')
->>> browser.getControl(name='form.copyrights.0..combination_01').value = (
-...     'http://www.zeit.de/')
 >>> browser.handleErrors = False
 >>> browser.getControl(name='form.actions.add').click()
 >>> browser.open('@@view.html')
@@ -89,8 +87,6 @@ It is possible to select the master image of an image group:
 >>> browser.getControl('Viewport').displayValue = ['Desktop']
 >>> browser.getControl(name='form.copyrights.0..combination_00').value = (
 ...     'ZEIT ONLINE')
->>> browser.getControl(name='form.copyrights.0..combination_01').value = (
-...     'http://www.zeit.de/')
 >>> browser.getControl('Apply').click()
 >>> browser.getControl('Image', index=0).displayValue
 ['obama-clinton-120x120.jpg']

--- a/src/zeit/content/image/browser/tests/test_image.py
+++ b/src/zeit/content/image/browser/tests/test_image.py
@@ -44,7 +44,7 @@ class TestImage(zeit.cms.testing.BrowserTestCase):
 
         b.getControl(name='form.copyrights.0..combination_00').value = (
             'ZEIT ONLINE')
-        b.getControl(name='form.copyrights.0..combination_01').value = (
+        b.getControl(name='form.copyrights.0..combination_03').value = (
             'http://www.zeit.de/')
         b.getControl(name='form.blob').add_file(
             pkg_resources.resource_stream(

--- a/src/zeit/content/image/browser/tests/test_imagegroup.py
+++ b/src/zeit/content/image/browser/tests/test_imagegroup.py
@@ -197,6 +197,21 @@ class ImageGroupBrowserTest(
         self.assertNotIn(
             'repository/imagegroup/@@variant.html', self.browser.contents)
 
+    def test_prefills_external_id_from_image_filename(self):
+        b = self.browser
+        self.add_imagegroup()
+        b.getControl(name='form.master_image_blobs.0.').add_file(
+            pkg_resources.resource_stream(
+                'zeit.content.image.browser',
+                'testdata/opernball.jpg'),
+            'image/jpeg', 'dpa Picture-Alliance-90999280-HighRes.jpg')
+        self.save_imagegroup()
+        with zeit.cms.testing.site(self.getRootFolder()):
+            group = self.repository['imagegroup']
+        self.assertEqual(
+            '90999280',
+            zeit.content.image.interfaces.IImageMetadata(group).external_id)
+
 
 class ImageGroupWebdriverTest(zeit.cms.testing.SeleniumTestCase):
 

--- a/src/zeit/content/image/browser/tests/test_imagegroup.py
+++ b/src/zeit/content/image/browser/tests/test_imagegroup.py
@@ -40,7 +40,7 @@ class ImageGroupHelperMixin(object):
         b = self.browser
         b.getControl(name='form.copyrights.0..combination_00').value = (
             'ZEIT ONLINE')
-        b.getControl(name='form.copyrights.0..combination_01').value = (
+        b.getControl(name='form.copyrights.0..combination_03').value = (
             'http://www.zeit.de/')
 
     def _upload_image(self, field, filename):

--- a/src/zeit/content/image/interfaces.py
+++ b/src/zeit/content/image/interfaces.py
@@ -93,6 +93,10 @@ class IImageMetadata(zope.interface.Interface):
                  title=_('set nofollow'),
                 required=False))))
 
+    external_id = zope.schema.TextLine(
+        title=_('External company ID'),
+        required=False)
+
     alt = zope.schema.TextLine(
         title=_("Alternative text"),
         description=_("Enter a textual description of the image"),

--- a/src/zeit/content/image/interfaces.py
+++ b/src/zeit/content/image/interfaces.py
@@ -6,6 +6,7 @@ import zc.form.interfaces
 import zc.sourcefactory.contextual
 import zeit.cms.content.contentsource
 import zeit.cms.content.interfaces
+import zeit.cms.content.sources
 import zeit.cms.interfaces
 import zeit.cms.repository.interfaces
 import zeit.cms.workingcopy.interfaces
@@ -23,6 +24,23 @@ class ImageProcessingError(TypeError):
 
 class IImageType(zeit.cms.interfaces.ICMSContentType):
     """The interface of image interfaces."""
+
+
+class CopyrightCompanySource(zeit.cms.content.sources.XMLSource):
+
+    product_configuration = 'zeit.content.image'
+    config_url = 'copyright-company-source'
+
+    def getValues(self, context):
+        tree = self._get_tree()
+        return [unicode(node)
+                for node in tree.iterchildren('*')
+                if self.isAvailable(node, context)]
+
+    def getTitle(self, context, value):
+        return value
+
+COPYRIGHT_COMPANY_SOURCE = CopyrightCompanySource()
 
 
 class IImageMetadata(zope.interface.Interface):
@@ -51,14 +69,22 @@ class IImageMetadata(zope.interface.Interface):
 
     copyrights = zope.schema.Tuple(
         title=_("Copyrights"),
-        default=((u'©', None, False),),
+        default=((u'©', None, None, None, False),),
         missing_value=(),
         required=False,
         value_type=zc.form.field.Combination(
             (zope.schema.TextLine(
-                title=_("Copyright"),
+                title=_('Photographer'),
                 min_length=3,
                 required=True),
+             zope.schema.Choice(
+                 title=_('Image company'),
+                 source=COPYRIGHT_COMPANY_SOURCE,
+                 required=False),
+             zope.schema.TextLine(
+                 title=_('Image company freetext'),
+                 description=_('Overrides image company'),
+                 required=False),
              zope.schema.URI(
                  title=_('Link'),
                  description=_('Link to copyright holder'),

--- a/src/zeit/content/image/metadata.py
+++ b/src/zeit/content/image/metadata.py
@@ -28,11 +28,14 @@ class ImageMetadata(object):
 
     @property
     def copyrights(self):
-        # migration for nofollow (VIV-104)
         result = list(self._copyrights)
         for i, item in enumerate(result):
+            # Migration for nofollow (VIV-104)
             if len(item) == 2:
-                result[i] = item + (False,)
+                result[i] = (item[0], None, None, item[1], False)
+            # Migration for companies (ZON-3174)
+            if len(item) == 3:
+                result[i] = (item[0], None, None, item[1], item[2])
         return tuple(result)
 
     @copyrights.setter
@@ -120,7 +123,7 @@ class XMLReferenceUpdater(zeit.cms.content.xmlsupport.XMLReferenceUpdater):
         for child in entry.iterchildren('copyright'):
             entry.remove(child)
 
-        for text, link, nofollow in context.copyrights:
+        for text, company, freetext, link, nofollow in context.copyrights:
             node = lxml.objectify.E.copyright(text)
             if link:
                 node.set('link', link)

--- a/src/zeit/content/image/metadata.py
+++ b/src/zeit/content/image/metadata.py
@@ -1,3 +1,4 @@
+from zeit.cms.content.interfaces import WRITEABLE_ALWAYS
 import grokcore.component as grok
 import lxml.objectify
 import zeit.cms.content.dav
@@ -15,11 +16,16 @@ class ImageMetadata(object):
     zeit.cms.content.dav.mapProperties(
         zeit.content.image.interfaces.IImageMetadata,
         zeit.content.image.interfaces.IMAGE_NAMESPACE,
-        ('alt', 'caption', 'links_to', 'nofollow', 'origin', 'external_id'))
+        ('alt', 'caption', 'links_to', 'nofollow', 'origin'))
     zeit.cms.content.dav.mapProperties(
         zeit.content.image.interfaces.IImageMetadata,
         'http://namespaces.zeit.de/CMS/document',
         ('title', 'year', 'volume'))
+
+    zeit.cms.content.dav.mapProperties(
+        zeit.content.image.interfaces.IImageMetadata,
+        zeit.content.image.interfaces.IMAGE_NAMESPACE,
+        ('external_id',), writeable=WRITEABLE_ALWAYS)
 
     _copyrights = zeit.cms.content.dav.DAVProperty(
         zeit.content.image.interfaces.IImageMetadata['copyrights'],

--- a/src/zeit/content/image/metadata.py
+++ b/src/zeit/content/image/metadata.py
@@ -15,7 +15,7 @@ class ImageMetadata(object):
     zeit.cms.content.dav.mapProperties(
         zeit.content.image.interfaces.IImageMetadata,
         zeit.content.image.interfaces.IMAGE_NAMESPACE,
-        ('alt', 'caption', 'links_to', 'nofollow', 'origin'))
+        ('alt', 'caption', 'links_to', 'nofollow', 'origin', 'external_id'))
     zeit.cms.content.dav.mapProperties(
         zeit.content.image.interfaces.IImageMetadata,
         'http://namespaces.zeit.de/CMS/document',

--- a/src/zeit/content/image/testing.py
+++ b/src/zeit/content/image/testing.py
@@ -18,6 +18,7 @@ product_config = """
     display-type-source file://{here}/tests/fixtures/display-types.xml
     variant-source file://{here}/tests/fixtures/variants.xml
     legacy-variant-source file://{here}/tests/fixtures/legacy-variants.xml
+    copyright-company-source file://{here}/tests/fixtures/copyright-company.xml
 </product-config>
 """.format(here=pkg_resources.resource_filename(__name__, '.'))
 

--- a/src/zeit/content/image/tests/fixtures/copyright-company.xml
+++ b/src/zeit/content/image/tests/fixtures/copyright-company.xml
@@ -1,0 +1,5 @@
+<companies>
+  <company>dpa</company>
+  <company>Getty Images</company>
+  <company>Reuters</company>
+</companies>


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/vivi-deployment/pull/35 and https://github.com/ZeitOnline/zeit.locales/pull/28

Frage: ist die Idee "suche eine zusammenhängende Kette von Ziffern" überhaupt der richtige Ansatz, um aus Bildnamen die Agentur-ID zu finden?