### PR TITLE
ZON-5136: Allow overriding output format when creating variant images, to support WEBP

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ zeit.content.image changes
 2.23.0 (unreleased)
 -------------------
 
+- ZON-5136: Allow overriding output format when creating variant images, to support WEBP
+
 - ZON-5134: Extract URL parsing into separate Traverser instead of ImageGroup.getitem
 
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.content.image changes
 ==========================
 
-2.22.6 (unreleased)
+2.23.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-5134: Extract URL parsing into separate Traverser instead of ImageGroup.getitem
 
 
 2.22.5 (2018-12-03)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.content.image',
-    version='2.22.6.dev0',
+    version='2.23.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/content/image/configure.zcml
+++ b/src/zeit/content/image/configure.zcml
@@ -77,6 +77,12 @@
     provides="z3c.traverser.interfaces.ITraverserPlugin"
     />
   <subscriber
+    factory=".imagegroup.VariantTraverser"
+    for=".interfaces.IRepositoryImageGroup
+         zeit.cms.browser.interfaces.ICMSLayer"
+    provides="z3c.traverser.interfaces.ITraverserPlugin"
+    />
+  <subscriber
     factory=".imagegroup.ThumbnailTraverser"
     for=".interfaces.IRepositoryImageGroup
          zeit.cms.browser.interfaces.ICMSLayer"

--- a/src/zeit/content/image/imagegroup.py
+++ b/src/zeit/content/image/imagegroup.py
@@ -103,7 +103,7 @@ class ImageGroupBase(object):
 
     def create_variant_image(
             self, variant, url=None,
-            size=None, scale=None, fill=None, viewport=None,
+            size=None, scale=None, fill=None, viewport=None, format=None,
             source=None):
         """Retrieve Variant and create an image according to options in URL.
         See VariantTraverser for allowed URLs.
@@ -144,7 +144,7 @@ class ImageGroupBase(object):
         if transform is None:
             return None
 
-        image = transform.create_variant_image(variant, size, fill)
+        image = transform.create_variant_image(variant, size, fill, format)
         image.__name__ = url or variant.name
         image.__parent__ = self
         image.uniqueId = u'%s%s' % (self.uniqueId, image.__name__)

--- a/src/zeit/content/image/testing.py
+++ b/src/zeit/content/image/testing.py
@@ -17,7 +17,6 @@ product_config = """
     viewport-source file://{here}/tests/fixtures/viewports.xml
     display-type-source file://{here}/tests/fixtures/display-types.xml
     variant-source file://{here}/tests/fixtures/variants.xml
-    legacy-variant-source file://{here}/tests/fixtures/legacy-variants.xml
     copyright-company-source file://{here}/tests/fixtures/copyright-company.xml
 </product-config>
 """.format(here=pkg_resources.resource_filename(__name__, '.'))

--- a/src/zeit/content/image/tests/fixtures/legacy-variants.xml
+++ b/src/zeit/content/image/tests/fixtures/legacy-variants.xml
@@ -1,4 +1,0 @@
-<legacy_variants>
-  <variant old="540x304" new="square" size="300x200" />
-  <variant old="148x84" new="invalid" />
-</legacy_variants>

--- a/src/zeit/content/image/tests/test_imagegroup.py
+++ b/src/zeit/content/image/tests/test_imagegroup.py
@@ -29,11 +29,6 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
         self.assertEqual('square', image.__name__)
         self.assertEqual('http://xml.zeit.de/group/square', image.uniqueId)
 
-    def test_getitem_uses_mapping_for_legacy_names_and_adjusts_size(self):
-        image = self.group['master-image-540x304.jpg']
-        self.assertTrue(zeit.content.image.interfaces.IImage.providedBy(image))
-        self.assertEqual((300, 200), image.getImageSize())
-
     def test_getitem_raises_keyerror_for_unmapped_legacy_names(self):
         with self.assertRaises(KeyError):
             self.group['master-image-111x222.jpg']
@@ -41,34 +36,6 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
     def test_getitem_raises_keyerror_for_wrongly_mapped_legacy_names(self):
         with self.assertRaises(KeyError):
             self.group['master-image-148x84.jpg']
-
-    def test_getitem_returns_materialized_files_for_new_syntax(self):
-        self.group['master-image-540x304.jpg'] = create_local_image(
-            'obama-clinton-120x120.jpg')
-        image = self.group['540x304']
-        self.assertTrue(zeit.content.image.interfaces.IImage.providedBy(image))
-        self.assertEqual((120, 120), image.getImageSize())
-
-    def test_getitem_can_scale_materialized_files_for_new_syntax(self):
-        master = PIL.Image.open(self.group['540x304__80x80'].open())
-        master_sample = master.getpixel((40, 20))
-        self.group['master-image-540x304.jpg'] = create_local_image(
-            'obama-clinton-120x120.jpg')
-        materialized = PIL.Image.open(self.group['540x304__80x80'].open())
-        materialized_sample = materialized.getpixel((40, 20))
-        self.assertNotEqual(master_sample, materialized_sample)
-        self.assertEqual((80, 80), materialized.size)
-
-    def test_getitem_can_scale_materialized_files_with_legacy_name(self):
-        master = PIL.Image.open(self.group['540x304__80x80'].open())
-        master_sample = master.getpixel((40, 20))
-        self.group['master-image-540x304.jpg'] = create_local_image(
-            'obama-clinton-120x120.jpg')
-        materialized = PIL.Image.open(
-            self.group['master-image-540x304__80x80'].open())
-        materialized_sample = materialized.getpixel((40, 20))
-        self.assertNotEqual(master_sample, materialized_sample)
-        self.assertEqual((80, 80), materialized.size)
 
     def test_getitem_handles_viewport_modifier(self):
         with self.assertNothingRaised():

--- a/src/zeit/content/image/tests/test_imagegroup.py
+++ b/src/zeit/content/image/tests/test_imagegroup.py
@@ -238,6 +238,7 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
         image = self.group.create_variant_image(
             zeit.content.image.interfaces.IVariants(self.group)['square'],
             format='WEBP')
+        self.assertEqual('image/webp', image.mimeType)
         image = PIL.Image.open(image.open())
         image.load()
         self.assertEqual('WEBP', image.format)

--- a/src/zeit/content/image/tests/test_imagegroup.py
+++ b/src/zeit/content/image/tests/test_imagegroup.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from zeit.content.image.testing import create_image_group_with_master_image
 from zeit.content.image.testing import create_local_image
-import PIL
+from zope.publisher.interfaces import NotFound
 import mock
 import zeit.cms.repository.interfaces
 import zeit.cms.testing
@@ -17,29 +17,39 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
     def setUp(self):
         super(ImageGroupTest, self).setUp()
         self.group = create_image_group_with_master_image()
+        self.request = zope.publisher.browser.TestRequest(
+            skin=zeit.cms.browser.interfaces.ICMSLayer)
+        self.full_traverser = zope.component.getMultiAdapter(
+            (self.group, self.request),
+            zope.publisher.interfaces.IPublishTraverse)
+        self.traverser = zeit.content.image.imagegroup.VariantTraverser(
+            self.group, self.request)
+
+    def traverse(self, name):
+        return self.full_traverser.publishTraverse(self.request, name)
 
     def test_getitem_returns_dav_content(self):
-        image = self.group['master-image.jpg']
+        image = self.traverse('master-image.jpg')
         self.assertTrue(zeit.content.image.interfaces.IImage.providedBy(image))
 
     def test_getitem_creates_image_from_variant_if_no_dav_content(self):
-        image = self.group['square']
+        image = self.traverse('square')
         self.assertTrue(zeit.content.image.interfaces.IImage.providedBy(image))
         self.assertEqual(self.group, image.__parent__)
         self.assertEqual('square', image.__name__)
         self.assertEqual('http://xml.zeit.de/group/square', image.uniqueId)
 
     def test_getitem_raises_keyerror_for_unmapped_legacy_names(self):
-        with self.assertRaises(KeyError):
-            self.group['master-image-111x222.jpg']
+        with self.assertRaises(NotFound):
+            self.traverse('master-image-111x222.jpg')
 
     def test_getitem_raises_keyerror_for_wrongly_mapped_legacy_names(self):
-        with self.assertRaises(KeyError):
-            self.group['master-image-148x84.jpg']
+        with self.assertRaises(NotFound):
+            self.traverse('master-image-148x84.jpg')
 
     def test_getitem_handles_viewport_modifier(self):
         with self.assertNothingRaised():
-            self.group['square__mobile']
+            self.traverse('square__mobile')
 
     def test_getitem_defines_no_variant_source_for_materialized_files(self):
         """It raises AttributeError when asked for `variant_source`.
@@ -49,18 +59,18 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
         `ImageGroupBase.create_variant_image` should have this attribute.
 
         """
-        image = self.group['master-image.jpg']
+        image = self.traverse('master-image.jpg')
         with self.assertRaises(AttributeError):
             image.variant_source
 
     def test_getitem_uses_primary_master_image_if_no_viewport_was_given(self):
-        image = self.group['square']
+        image = self.traverse('square')
         self.assertEqual('master-image.jpg', image.variant_source)
 
     def test_getitem_uses_primary_master_image_if_viewport_not_configured(
             self):
         """Default configuration only includes `desktop`, but not `mobile`."""
-        image = self.group['square__mobile']
+        image = self.traverse('square__mobile')
         self.assertEqual('master-image.jpg', image.variant_source)
 
     def test_getitem_chooses_master_image_using_given_viewport(self):
@@ -75,10 +85,10 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
                 ('mobile', 'master-image-mobile.jpg'))
             self.assertEqual(
                 'master-image.jpg',
-                self.group['square__desktop'].variant_source)
+                self.traverse('square__desktop').variant_source)
             self.assertEqual(
                 'master-image-mobile.jpg',
-                self.group['square__mobile'].variant_source)
+                self.traverse('square__mobile').variant_source)
 
     def test_getitem_ignores_master_image_for_viewport_if_nonexistent(self):
         with mock.patch(
@@ -87,11 +97,11 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
             master_images.return_value = (('desktop', 'nonexistent.jpg'),)
             self.assertEqual(
                 'master-image.jpg',
-                self.group['square__desktop'].variant_source)
+                self.traverse('square__desktop').variant_source)
 
     def test_getitem_raises_keyerror_if_variant_does_not_exist(self):
-        with self.assertRaises(KeyError):
-            self.group['nonexistent']
+        with self.assertRaises(NotFound):
+            self.traverse('nonexistent')
 
     def test_variant_url_returns_path_with_size_if_given(self):
         self.assertEqual('/group/square__200x200', self.group.variant_url(
@@ -106,14 +116,14 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
 
     def test_returns_image_for_variant_with_size(self):
         self.assertEqual(
-            (200, 200), self.group['square__200x200'].getImageSize())
+            (200, 200), self.traverse('square__200x200').getImageSize())
 
     def test_invalid_size_raises_keyerror(self):
-        with self.assertRaises(KeyError):
-            self.group['square__0x200']
+        with self.assertRaises(NotFound):
+            self.traverse('square__0x200')
 
-        with self.assertRaises(KeyError):
-            self.group['square__-1x200']
+        with self.assertRaises(NotFound):
+            self.traverse('square__-1x200')
 
     def test_variant_url_returns_path_with_fill_color_if_given(self):
         self.assertEqual(
@@ -121,38 +131,38 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
                 'square', 200, 200, '0000ff'))
 
     def test_dav_content_with_same_name_is_preferred(self):
-        self.assertEqual((1536, 1536), self.group['square'].getImageSize())
+        self.assertEqual((1536, 1536), self.traverse('square').getImageSize())
         self.group['square'] = zeit.content.image.testing.create_local_image(
             'new-hampshire-450x200.jpg')
-        self.assertEqual((450, 200), self.group['square'].getImageSize())
+        self.assertEqual((450, 200), self.traverse('square').getImageSize())
 
     def test_thumbnails_create_variants_from_smaller_master_image(self):
-        self.assertEqual((1536, 1536), self.group['square'].getImageSize())
+        self.assertEqual((1536, 1536), self.traverse('square').getImageSize())
         thumbnails = zeit.content.image.interfaces.IThumbnails(self.group)
         self.assertEqual((750, 750), thumbnails['square'].getImageSize())
 
     def test_can_access_small_variant_via_name_and_size(self):
-        variant = self.group.get_variant_by_size('cinema__200x100')
+        variant = self.traverser._parse_variant_by_size('cinema__200x100')
         self.assertEqual('cinema-small', variant.id)
 
     def test_defaults_to_variant_without_size_limitation_if_size_too_big(self):
-        variant = self.group.get_variant_by_size('cinema__9999x9999')
+        variant = self.traverser._parse_variant_by_size('cinema__9999x9999')
         self.assertEqual('cinema-large', variant.id)
 
     def test_invalid_names_should_return_none(self):
         self.assertEqual(
-            None, self.group.get_variant_by_size('foobarbaz__9999x9999'))
+            None, self.traverser._parse_variant_by_size('foobarbaz__9999x9999'))
         self.assertEqual(
-            None, self.group.get_variant_by_size('cinema__200xfoo'))
+            None, self.traverser._parse_variant_by_size('cinema__200xfoo'))
         self.assertEqual(
-            None, self.group.get_variant_by_size('cinema__800x'))
+            None, self.traverser._parse_variant_by_size('cinema__800x'))
 
     def test_no_size_matches_returns_none(self):
         from zeit.content.image.variant import Variants, Variant
         with mock.patch.object(Variants, 'values', return_value=[
                 Variant(name='foo', id='small', max_size='100x100')]):
             self.assertEqual(
-                None, self.group.get_variant_by_size('foo__9999x9999'))
+                None, self.traverser._parse_variant_by_size('foo__9999x9999'))
 
     def test_master_image_is_None_if_no_master_images_defined(self):
         group = zeit.content.image.imagegroup.ImageGroup()
@@ -182,20 +192,21 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
     def test_device_pixel_ratio_affects_image_size(self):
         self.assertEqual(
             (600, 320),
-            self.group['cinema__300x160__scale_2.0'].getImageSize())
+            self.traverse('cinema__300x160__scale_2.0').getImageSize())
         self.assertEqual(
-            (180, 96), self.group['cinema__300x160__scale_0.6'].getImageSize())
+            (180, 96),
+            self.traverse('cinema__300x160__scale_0.6').getImageSize())
         self.assertEqual(
             (675, 360),
-            self.group['cinema__300x160__scale_2.25'].getImageSize())
+            self.traverse('cinema__300x160__scale_2.25').getImageSize())
 
     def test_unallowed_device_pixel_ratio_is_ignored(self):
         self.assertEqual(
             (300, 160),
-            self.group['cinema__300x160__scale_0.2'].getImageSize())
+            self.traverse('cinema__300x160__scale_0.2').getImageSize())
         self.assertEqual(
             (300, 160),
-            self.group['cinema__300x160__scale_99999'].getImageSize())
+            self.traverse('cinema__300x160__scale_99999').getImageSize())
 
     def test_scaled_image_get_zoom_from_non_scaled_size(self):
         self.group.variants = {
@@ -204,18 +215,18 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
         }
         self.assertEqual(
             0.3,
-            self.group.get_variant_by_size('cinema__300x160__scale_2.0').zoom)
+            self.traverser._parse_variant_by_size('cinema__300x160__scale_2.0').zoom)
         self.assertEqual(
-            0.3, self.group.get_variant_by_size('cinema__300x160').zoom)
+            0.3, self.traverser._parse_variant_by_size('cinema__300x160').zoom)
         self.assertEqual(
-            1.0, self.group.get_variant_by_size('cinema__600x320').zoom)
+            1.0, self.traverser._parse_variant_by_size('cinema__600x320').zoom)
 
     def test_does_not_change_external_id_when_already_set(self):
         meta = zeit.content.image.interfaces.IImageMetadata(self.group)
         meta.external_id = u'12345'
         self.group['6789.jpg'] = create_local_image('opernball.jpg')
         zope.event.notify(zope.lifecycleevent.ObjectAddedEvent(
-            self.group['6789.jpg']))
+            self.traverse('6789.jpg')))
         self.assertEqual('12345', meta.external_id)
 
     def test_delete_group_does_not_try_to_recreate_deleted_children(self):

--- a/src/zeit/content/image/tests/test_imagegroup.py
+++ b/src/zeit/content/image/tests/test_imagegroup.py
@@ -2,6 +2,7 @@
 from zeit.content.image.testing import create_image_group_with_master_image
 from zeit.content.image.testing import create_local_image
 from zope.publisher.interfaces import NotFound
+import PIL
 import mock
 import zeit.cms.repository.interfaces
 import zeit.cms.testing
@@ -232,6 +233,14 @@ class ImageGroupTest(zeit.cms.testing.FunctionalTestCase):
     def test_delete_group_does_not_try_to_recreate_deleted_children(self):
         with self.assertNothingRaised():
             del self.group.__parent__[self.group.__name__]
+
+    def test_create_variant_image_allows_overriding_output_format(self):
+        image = self.group.create_variant_image(
+            zeit.content.image.interfaces.IVariants(self.group)['square'],
+            format='WEBP')
+        image = PIL.Image.open(image.open())
+        image.load()
+        self.assertEqual('WEBP', image.format)
 
 
 class ExternalIDTest(zeit.cms.testing.FunctionalTestCase):

--- a/src/zeit/content/image/transform.py
+++ b/src/zeit/content/image/transform.py
@@ -178,7 +178,7 @@ class ImageTransform(object):
             options = {'optimize': True}
         else:
             options = {}
-        pil_image.save(image.open('w'), self.image.format, **options)
+        pil_image.save(image.open('w'), self.context.format, **options)
         image.__parent__ = self.context
         image_times = zope.dublincore.interfaces.IDCTimes(self.context, None)
         if image_times and image_times.modified:

--- a/src/zeit/content/image/transform.py
+++ b/src/zeit/content/image/transform.py
@@ -169,10 +169,12 @@ class ImageTransform(object):
         return pil_image
 
     def _construct_image(self, pil_image, format=None):
+        image = zeit.content.image.image.TemporaryImage()
         if not format:
             format = self.context.format
-        image = zeit.content.image.image.TemporaryImage()
-        image.mimeType = self.context.mimeType
+            image.mimeType = self.context.mimeType
+        else:
+            image.mimeType = 'image/' + format.lower()  # XXX crude heuristic.
         # XXX Maybe encoder setting should be made configurable.
         if format in ('JPG', 'JPEG'):
             options = {'progressive': True, 'quality': 85, 'optimize': True}

--- a/src/zeit/content/image/transform.py
+++ b/src/zeit/content/image/transform.py
@@ -46,7 +46,8 @@ class ImageTransform(object):
         image = self.image.resize((width, height), filter)
         return self._construct_image(image)
 
-    def create_variant_image(self, variant, size=None, fill_color=None):
+    def create_variant_image(
+            self, variant, size=None, fill_color=None, format=None):
         """Create variant image from source image.
 
         Will crop the image according to the zoom, focus point and size. In
@@ -56,7 +57,6 @@ class ImageTransform(object):
         The default variant skips cropping, but still applies image
         enhancements, so it can be used as a high quality preview of image
         enhancements in the frontend.
-
         """
         if not variant.is_default:
             image = self._crop_variant_image(variant, size=size)
@@ -86,7 +86,7 @@ class ImageTransform(object):
             opaque.paste(image, (0, 0), image)
             image = opaque
 
-        return self._construct_image(image)
+        return self._construct_image(image, format)
 
     def _crop_variant_image(self, variant, size=None):
         """Crop variant image from source image.
@@ -168,17 +168,21 @@ class ImageTransform(object):
             pil_image = pil_image.convert(self._color_mode)
         return pil_image
 
-    def _construct_image(self, pil_image):
+    def _construct_image(self, pil_image, format=None):
+        if not format:
+            format = self.context.format
         image = zeit.content.image.image.TemporaryImage()
         image.mimeType = self.context.mimeType
         # XXX Maybe encoder setting should be made configurable.
-        if self.context.format in ('JPG', 'JPEG'):
+        if format in ('JPG', 'JPEG'):
             options = {'progressive': True, 'quality': 85, 'optimize': True}
-        elif self.context.format in ('PNG',):
+        elif format == 'PNG':
             options = {'optimize': True}
+        elif format == 'WEBP':
+            options = {'quality': 85}
         else:
             options = {}
-        pil_image.save(image.open('w'), self.context.format, **options)
+        pil_image.save(image.open('w'), format, **options)
         image.__parent__ = self.context
         image_times = zope.dublincore.interfaces.IDCTimes(self.context, None)
         if image_times and image_times.modified:

--- a/src/zeit/content/image/transform.py
+++ b/src/zeit/content/image/transform.py
@@ -172,9 +172,9 @@ class ImageTransform(object):
         image = zeit.content.image.image.TemporaryImage()
         image.mimeType = self.context.mimeType
         # XXX Maybe encoder setting should be made configurable.
-        if self.context.format.upper() in ('JPG', 'JPEG'):
+        if self.context.format in ('JPG', 'JPEG'):
             options = {'progressive': True, 'quality': 85, 'optimize': True}
-        elif self.context.format.upper() in ('PNG',):
+        elif self.context.format in ('PNG',):
             options = {'optimize': True}
         else:
             options = {}

--- a/src/zeit/content/image/variant.py
+++ b/src/zeit/content/image/variant.py
@@ -83,8 +83,6 @@ class Variant(object):
     brightness = None
     contrast = None
     fallback_size = None
-    legacy_name = None
-    legacy_size = None
     max_size = None
     saturation = None
     sharpness = None
@@ -237,28 +235,3 @@ def imagegroup_for_variants(context):
 @grok.implementer(zeit.content.image.interfaces.IImageGroup)
 def imagegroup_for_variant(context):
     return zeit.content.image.interfaces.IImageGroup(context.__parent__)
-
-
-class LegacyVariantSource(zeit.cms.content.sources.XMLSource):
-
-    product_configuration = 'zeit.content.image'
-    config_url = 'legacy-variant-source'
-
-    def getValues(self, context):
-        tree = self._get_tree()
-        result = []
-        for node in tree.iterchildren('*'):
-            size = None
-            try:
-                size = [int(x) for x in node.get('size', '').split('x')]
-            except (IndexError, ValueError):
-                pass
-
-            result.append({
-                'old': node.get('old'),
-                'new': node.get('new'),
-                'size': size,
-            })
-        return result
-
-LEGACY_VARIANT_SOURCE = LegacyVariantSource()


### PR DESCRIPTION
Includes ZON-5134: Extract URL parsing into separate Traverser instead of ImageGroup.getitem

Am besten commitweise anschauen (es ist ziemlich viel Code verschoben worden, was den Diff noisy macht).

Kann sofort deployed werden, wird erst benutzt, wenn https://github.com/ZeitOnline/zeit.web/pull/3144 deployed ist und der Feature-Toggle `webp` aktiviert wird (_das_ wiederum hat Abhänigkeiten, die stehen am genannten PR).